### PR TITLE
chore: .env.example削除に伴うCI設定とドキュメント更新

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,7 +85,6 @@ dotenvx による暗号化管理:
 
 - `.env` - 暗号化済み（コミット対象）
 - `.env.keys` - 秘密鍵（**絶対にコミットしない**）
-- `.env.example` - テンプレート
 
 認証情報の取得先:
 
@@ -99,10 +98,13 @@ dotenvx による暗号化管理:
 ## 次のステップ
 
 1. Clerk と Supabase プロジェクトを作成
-2. `.env` に実際の認証情報を設定
-3. `pnpm env:encrypt` で環境変数を暗号化（推奨）
-4. `pnpm db:generate` で Prisma Client を生成
-5. 開発サーバー起動
-   - 暗号化した場合: `pnpm env:run -- pnpm dev`
-   - 暗号化していない場合: `pnpm dev`
-6. `/sign-in` でサインイン確認
+2. 環境変数を復号化して編集
+   ```bash
+   # .envを復号化して一時的に平文で編集
+   pnpm dotenvx decrypt
+   # 編集後に再暗号化
+   pnpm env:encrypt
+   ```
+3. `pnpm db:generate` で Prisma Client を生成
+4. 開発サーバー起動: `pnpm env:run -- pnpm dev`
+5. `/sign-in` でサインイン確認

--- a/.claude/rules/dotenvx.md
+++ b/.claude/rules/dotenvx.md
@@ -67,11 +67,11 @@ git commit -m "chore: update environment variables"
 ### 2. 手動で編集
 
 ```bash
-# 1. 平文の .env を作成
-cp .env.example .env
-vim .env  # 値を設定
+# 1. 既存の .env を復号化
+dotenvx decrypt  # 一時的に平文化
+vim .env  # 値を編集
 
-# 2. 暗号化
+# 2. 再暗号化
 pnpm env:encrypt
 
 # 3. コミット

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,17 +75,6 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
 
-      - name: Setup environment variables
-        run: |
-          if [ -n "$DOTENV_PRIVATE_KEY" ]; then
-            echo "Using encrypted .env with dotenvx"
-          else
-            echo "DOTENV_PRIVATE_KEY not set, using .env.example"
-            cp .env.example .env
-          fi
-        env:
-          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
-
       - name: Run tests
         run: pnpm env:run pnpm test:run
         env:
@@ -104,17 +93,6 @@ jobs:
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
-
-      - name: Setup environment variables
-        run: |
-          if [ -n "$DOTENV_PRIVATE_KEY" ]; then
-            echo "Using encrypted .env with dotenvx"
-          else
-            echo "DOTENV_PRIVATE_KEY not set, using .env.example"
-            cp .env.example .env
-          fi
-        env:
-          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
 
       - name: Run build
         run: pnpm env:run pnpm build:cf


### PR DESCRIPTION
## 概要

PR #10 で `.env.example` を削除したことに伴い、CI設定とドキュメントを更新しました。

## 変更内容

### CI設定 (.github/workflows/ci.yml)
- **削除**: `.env.example` へのフォールバック処理を削除
  - test ジョブ
  - build ジョブ
- **影響**: `DOTENV_PRIVATE_KEY` が設定されていない場合、CIは失敗します
  - GitHub Secrets に設定済みのため、本リポジトリのCIには影響なし
  - フォークからのPRは環境変数が必要

### ドキュメント更新

#### .claude/CLAUDE.md
- `.env.example` の記載を削除
- セットアップ手順を dotenvx 前提に更新
  ```bash
  # 新しい手順
  pnpm dotenvx decrypt  # 復号化
  # 編集
  pnpm env:encrypt      # 再暗号化
  ```

#### .claude/rules/dotenvx.md
- 手動編集の手順を更新
  - 変更前: `cp .env.example .env` → 編集 → 暗号化
  - 変更後: `dotenvx decrypt` → 編集 → 再暗号化

## 理由

- 実際の `.env` が dotenvx で暗号化管理されている
- `.env.example` はテンプレートとして不要
- dotenvx による暗号化管理に完全移行

## テスト

- CI で既存のテストが正常に動作することを確認
- ドキュメントの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)