### PR TITLE
fix: DashboardでのToast通知使用の修正

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,38 @@
+import '../src/app/globals.css'
+import { withThemeByClassName } from '@storybook/addon-themes'
+import type { Preview } from '@storybook/react'
+import { Toaster } from '@/components/ui/sonner'
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    nextjs: {
+      appDirectory: true,
+    },
+    backgrounds: {
+      disable: true,
+    },
+  },
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: '',
+        dark: 'dark',
+      },
+      defaultTheme: 'light',
+    }),
+    (Story) => (
+      <>
+        <Story />
+        <Toaster position="bottom-right" richColors />
+      </>
+    ),
+  ],
+}
+
+export default preview

--- a/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
+++ b/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
@@ -4,7 +4,6 @@ import { createId } from '@paralleldrive/cuid2'
 import { Result } from '@praha/byethrow'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
 import { toggleCheckinAction } from '@/app/actions/habits/checkin'
 import { createHabit } from '@/app/actions/habits/create'
 import type { IconName } from '@/components/Icon'
@@ -16,7 +15,7 @@ import {
   DEFAULT_HABIT_FREQUENCY,
   DEFAULT_HABIT_PERIOD,
 } from '@/constants/habit'
-import { formatSerializableError } from '@/lib/errors/serializable'
+import { appToast } from '@/lib/utils/toast'
 import type { HabitWithProgress } from '@/types/habit'
 
 interface Checkin {
@@ -86,10 +85,7 @@ export function DashboardWrapper({ habits, todayCheckins, user }: DashboardWrapp
     }
 
     setOptimisticHabits((current) => current.filter((habit) => habit.id !== optimisticId))
-    console.error('習慣の作成に失敗しました:', result.error)
-    toast.error('習慣の作成に失敗しました', {
-      description: formatSerializableError(result.error),
-    })
+    appToast.error('習慣の作成に失敗しました', result.error)
   }
 
   const handleToggleCheckin = async (habitId: string) => {
@@ -163,15 +159,11 @@ export function DashboardWrapper({ habits, todayCheckins, user }: DashboardWrapp
 
       setOptimisticCheckins((current) => rollbackOptimisticCheckins(current))
       setOptimisticHabits((current) => updateHabitProgress(current, isCompleted ? 1 : -1))
-      console.error('チェックインの切り替えに失敗しました:', result.error)
-      toast.error('チェックインの切り替えに失敗しました', {
-        description: result.error.message,
-      })
+      appToast.error('チェックインの切り替えに失敗しました', result.error)
     } catch (error) {
       setOptimisticCheckins((current) => rollbackOptimisticCheckins(current))
       setOptimisticHabits((current) => updateHabitProgress(current, isCompleted ? 1 : -1))
-      console.error('チェックインの切り替えに失敗しました:', error)
-      toast.error('チェックインの切り替えに失敗しました')
+      appToast.error('チェックインの切り替えに失敗しました', error)
     } finally {
       setPendingCheckins((current) => {
         const next = new Set(current)

--- a/src/components/settings/WeekStartSettings.tsx
+++ b/src/components/settings/WeekStartSettings.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { useState } from 'react'
-import { toast } from 'sonner'
 import { updateWeekStartAction } from '@/app/actions/settings/updateWeekStart'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { useWeekStart } from '@/hooks/use-week-start'
+import { appToast } from '@/lib/utils/toast'
 
 export function WeekStartSettings() {
   const { weekStart, setWeekStart, ready } = useWeekStart()
@@ -18,9 +18,9 @@ export function WeekStartSettings() {
       try {
         await updateWeekStartAction(value)
         setWeekStart(value)
-        toast.success('週の開始日を更新しました')
-      } catch {
-        toast.error('更新に失敗しました')
+        appToast.success('週の開始日を更新しました')
+      } catch (error) {
+        appToast.error('更新に失敗しました', error)
       } finally {
         setIsUpdating(false)
       }

--- a/src/components/streak/DashboardHeader.stories.tsx
+++ b/src/components/streak/DashboardHeader.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { storybookToast } from '@/lib/storybook'
+import { DashboardHeader } from './DashboardHeader'
+
+const meta = {
+  title: 'Streak/DashboardHeader',
+  component: DashboardHeader,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DashboardHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Mobile: Story = {
+  args: {
+    variant: 'mobile',
+    todayCompleted: 5,
+    totalDaily: 8,
+    totalStreak: 12,
+  },
+}
+
+export const Desktop: Story = {
+  args: {
+    variant: 'desktop',
+    todayCompleted: 5,
+    totalDaily: 8,
+    totalStreak: 12,
+    onAddClick: () => {
+      storybookToast.success('追加ボタンがクリックされました', 'これはStorybookでのデモです')
+    },
+  },
+}
+
+export const DesktopCompleted: Story = {
+  args: {
+    variant: 'desktop',
+    todayCompleted: 8,
+    totalDaily: 8,
+    totalStreak: 30,
+    onAddClick: () => {
+      storybookToast.success('すべての習慣を完了しました！', '素晴らしい習慣継続です')
+    },
+  },
+}
+
+export const MobileZero: Story = {
+  args: {
+    variant: 'mobile',
+    todayCompleted: 0,
+    totalDaily: 5,
+    totalStreak: 0,
+  },
+}

--- a/src/lib/storybook.tsx
+++ b/src/lib/storybook.tsx
@@ -1,0 +1,26 @@
+import { toast } from 'sonner'
+
+/**
+ * Storybookでのデモ用toastヘルパー
+ * SSR環境では何もしない
+ */
+export const storybookToast = {
+  success: (message: string, description?: string) => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    toast.success(message, { description })
+  },
+  error: (message: string, description?: string) => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    toast.error(message, { description })
+  },
+  info: (message: string, description?: string) => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    toast.info(message, { description })
+  },
+}

--- a/src/lib/utils/toast.ts
+++ b/src/lib/utils/toast.ts
@@ -1,0 +1,30 @@
+import { toast } from 'sonner'
+
+/**
+ * 統一されたtoastヘルパー
+ * エラー時はconsole.errorも出力する
+ */
+export const appToast = {
+  success: (message: string, description?: string) => {
+    toast.success(message, { description })
+  },
+  error: (message: string, error?: Error | { message: string } | unknown) => {
+    // エラー詳細をコンソールに出力
+    if (error) {
+      console.error(message, error)
+    }
+
+    // ユーザー向けに簡潔なメッセージを表示
+    let description: string | undefined
+    if (error instanceof Error) {
+      description = error.message
+    } else if (typeof error === 'object' && error !== null && 'message' in error) {
+      description = (error as { message: string }).message
+    }
+
+    toast.error(message, { description })
+  },
+  info: (message: string, description?: string) => {
+    toast.info(message, { description })
+  },
+}


### PR DESCRIPTION
## 概要

Storybook環境でtoast通知コンポーネントを正しく動作するように修正しました。

## 種別

- [x] 🐛 fix (バグ修正)
- [ ] 🚀 feature (新機能)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Drizzle)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

🤖 Generated with [Claude Code](https://claude.ai/code)