### PR TITLE
fix: sync theme-color with resolved theme

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,11 +3,18 @@ import type { Metadata, Viewport } from 'next'
 import { cookies } from 'next/headers'
 import type React from 'react'
 import { ColorThemeScript } from '@/components/basics/ColorThemeScript'
+import { ThemeModeScript } from '@/components/basics/ThemeModeScript'
 import { ThemeProvider } from '@/components/basics/ThemeProvider'
 import { A2HSPrompt } from '@/components/pwa/A2HSPrompt'
 import { ServiceWorkerRegistration } from '@/components/pwa/ServiceWorkerRegistration'
 import { Toaster } from '@/components/ui/sonner'
-import { COLOR_THEME_COOKIE_KEY, DEFAULT_THEME_MODE, isColorTheme, THEME_MODE_COOKIE_KEY } from '@/constants/theme'
+import {
+  COLOR_THEME_COOKIE_KEY,
+  DEFAULT_THEME_MODE,
+  isColorTheme,
+  THEME_COLOR_LIGHT,
+  THEME_MODE_COOKIE_KEY,
+} from '@/constants/theme'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -32,7 +39,6 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: '#000000',
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -55,6 +61,9 @@ export default async function RootLayout({
     <ClerkProvider>
       <html className={htmlClassName} data-theme={colorTheme} lang="ja" suppressHydrationWarning>
         <head>
+          <meta content="light dark" name="color-scheme" />
+          <meta content={THEME_COLOR_LIGHT} name="theme-color" />
+          <ThemeModeScript />
           <ColorThemeScript />
         </head>
         <body>

--- a/src/components/basics/ThemeModeScript.tsx
+++ b/src/components/basics/ThemeModeScript.tsx
@@ -1,0 +1,32 @@
+import { DEFAULT_THEME_MODE, THEME_COLOR_DARK, THEME_COLOR_LIGHT, THEME_MODE_COOKIE_KEY } from '@/constants/theme'
+
+const themeModeScript = `
+(function() {
+  try {
+    var cookieValue = document.cookie
+      .split('; ')
+      .find(function (row) { return row.startsWith('${THEME_MODE_COOKIE_KEY}='); });
+    var value = cookieValue ? decodeURIComponent(cookieValue.split('=').slice(1).join('=')) : null;
+    var mode = value === 'light' || value === 'dark' || value === 'system' ? value : '${DEFAULT_THEME_MODE}';
+    var resolved = mode;
+    if (mode === 'system') {
+      var mql = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+      resolved = mql && mql.matches ? 'dark' : 'light';
+    }
+    var root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(resolved);
+    var meta = document.querySelector('meta[name="theme-color"]');
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.setAttribute('name', 'theme-color');
+      document.head.appendChild(meta);
+    }
+    meta.setAttribute('content', resolved === 'dark' ? '${THEME_COLOR_DARK}' : '${THEME_COLOR_LIGHT}');
+  } catch (e) {}
+})();
+`
+
+export function ThemeModeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: themeModeScript }} suppressHydrationWarning />
+}

--- a/src/components/basics/ThemeProvider.tsx
+++ b/src/components/basics/ThemeProvider.tsx
@@ -2,13 +2,13 @@
 
 import { ThemeProvider as NextThemesProvider, useTheme } from 'next-themes'
 import { useEffect } from 'react'
-import { DEFAULT_THEME_MODE, THEME_MODE_COOKIE_KEY } from '@/constants/theme'
+import { DEFAULT_THEME_MODE, THEME_COLOR_DARK, THEME_COLOR_LIGHT, THEME_MODE_COOKIE_KEY } from '@/constants/theme'
 import { setClientCookie } from '@/lib/utils/cookies'
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 
 function ThemeCookieSync() {
-  const { theme } = useTheme()
+  const { resolvedTheme, theme } = useTheme()
 
   useEffect(() => {
     if (!theme) {
@@ -21,6 +21,21 @@ function ThemeCookieSync() {
       sameSite: 'lax',
     })
   }, [theme])
+
+  useEffect(() => {
+    if (!resolvedTheme) {
+      return
+    }
+
+    let meta = document.querySelector('meta[name="theme-color"]') as HTMLMetaElement | null
+    if (!meta) {
+      meta = document.createElement('meta')
+      meta.setAttribute('name', 'theme-color')
+      document.head.appendChild(meta)
+    }
+
+    meta.setAttribute('content', resolvedTheme === 'dark' ? THEME_COLOR_DARK : THEME_COLOR_LIGHT)
+  }, [resolvedTheme])
 
   return null
 }

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -4,5 +4,7 @@ export const COLOR_THEME_COOKIE_KEY = 'color-theme'
 export const COLOR_THEMES = ['lime', 'orange', 'red', 'pink', 'purple', 'blue', 'cyan', 'yellow'] as const
 export type ColorThemeName = (typeof COLOR_THEMES)[number]
 export const DEFAULT_COLOR_THEME: ColorThemeName = 'lime'
+export const THEME_COLOR_LIGHT = '#ffffff'
+export const THEME_COLOR_DARK = '#000000'
 
 export const isColorTheme = (value: string): value is ColorThemeName => COLOR_THEMES.includes(value as ColorThemeName)


### PR DESCRIPTION
## 概要

- theme-color を初期描画時とテーマ切替時に同期
- color-scheme meta を追加
- テーマ色の定数を追加

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [x] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

補足: `mise run ci` は実行済みです。
