### PR TITLE
fix: reduce checkin timeouts

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2'
-import { boolean, date, integer, pgEnum, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { boolean, date, index, integer, pgEnum, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 import {
   DEFAULT_HABIT_COLOR,
   DEFAULT_HABIT_FREQUENCY,
@@ -24,34 +24,46 @@ export const users = pgTable('User', {
     .notNull(),
 })
 
-export const habits = pgTable('Habit', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  userId: text('userId')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  icon: text('icon').default(DEFAULT_HABIT_ICON),
-  color: text('color').default(DEFAULT_HABIT_COLOR),
-  period: taskPeriodEnum('period').default(DEFAULT_HABIT_PERIOD).notNull(),
-  frequency: integer('frequency').default(DEFAULT_HABIT_FREQUENCY).notNull(),
-  archived: boolean('archived').default(false).notNull(),
-  archivedAt: timestamp('archivedAt', { mode: 'date' }),
-  createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
-  updatedAt: timestamp('updatedAt', { mode: 'date' })
-    .$onUpdate(() => new Date())
-    .defaultNow()
-    .notNull(),
-})
+export const habits = pgTable(
+  'Habit',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    icon: text('icon').default(DEFAULT_HABIT_ICON),
+    color: text('color').default(DEFAULT_HABIT_COLOR),
+    period: taskPeriodEnum('period').default(DEFAULT_HABIT_PERIOD).notNull(),
+    frequency: integer('frequency').default(DEFAULT_HABIT_FREQUENCY).notNull(),
+    archived: boolean('archived').default(false).notNull(),
+    archivedAt: timestamp('archivedAt', { mode: 'date' }),
+    createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
+    updatedAt: timestamp('updatedAt', { mode: 'date' })
+      .$onUpdate(() => new Date())
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    userIdIndex: index('Habit_userId_idx').on(table.userId),
+  })
+)
 
-export const checkins = pgTable('Checkin', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  habitId: text('habitId')
-    .notNull()
-    .references(() => habits.id, { onDelete: 'cascade' }),
-  date: date('date', { mode: 'string' }).notNull(),
-  createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
-})
+export const checkins = pgTable(
+  'Checkin',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    habitId: text('habitId')
+      .notNull()
+      .references(() => habits.id, { onDelete: 'cascade' }),
+    date: date('date', { mode: 'string' }).notNull(),
+    createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
+  },
+  (table) => ({
+    habitDateIndex: index('Checkin_habitId_date_idx').on(table.habitId, table.date),
+  })
+)


### PR DESCRIPTION
## 概要
- チェックイン時のタイムアウト対策として、既存ユーザーで email クレームが無い場合は同期を短絡し、クレームがある場合はそれで upsert
- Habit / Checkin のクエリ向けインデックスを追加（Habit.userId / Checkin.habitId+date）
- 検証: agent-browser + Cloudflare tail で /dashboard の timeout を再現・確認

## 種別
- [x] 🐛 fix (バグ修正)
- [ ] 🚀 feature (新機能)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [ ] フロントエンド
- [x] API / Server Actions
- [x] データベース (Prisma)
- [x] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue
- なし

## 確認済み
- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise ci`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

メモ: `drizzle/` が .gitignore 対象のため、DB への反映は `pnpm db:push` か `pnpm db:generate` + `pnpm db:migrate` で適用してください。
