### PR TITLE
refactor: dedupe habit actions and dashboard props

### DIFF
--- a/src/app/actions/habits/archive.ts
+++ b/src/app/actions/habits/archive.ts
@@ -1,10 +1,7 @@
 'use server'
 
-import { actionError, actionOk } from '@/lib/actions/result'
-import { NotFoundError } from '@/lib/errors/habit'
-import { serializeHabitError } from '@/lib/errors/serializable'
 import { archiveHabit } from '@/lib/queries/habit'
-import { type HabitActionResult, requireOwnedHabit, requireUserId, revalidateHabitPaths } from './utils'
+import { type HabitActionResult, runHabitMutation } from './utils'
 
 /**
  * 習慣をアーカイブするServer Action
@@ -13,25 +10,5 @@ import { type HabitActionResult, requireOwnedHabit, requireUserId, revalidateHab
  * @returns ServerActionResult<void, SerializableHabitError>
  */
 export async function archiveHabitAction(habitId: string): HabitActionResult {
-  const userIdResult = await requireUserId()
-
-  if (!userIdResult.ok) {
-    return userIdResult
-  }
-
-  const habitResult = await requireOwnedHabit(habitId, userIdResult.data)
-
-  if (!habitResult.ok) {
-    return habitResult
-  }
-
-  const archived = await archiveHabit(habitId, userIdResult.data)
-
-  if (!archived) {
-    return actionError(serializeHabitError(new NotFoundError()))
-  }
-
-  revalidateHabitPaths()
-
-  return actionOk()
+  return await runHabitMutation(habitId, archiveHabit)
 }

--- a/src/app/actions/habits/unarchive.ts
+++ b/src/app/actions/habits/unarchive.ts
@@ -1,10 +1,7 @@
 'use server'
 
-import { actionError, actionOk } from '@/lib/actions/result'
-import { NotFoundError } from '@/lib/errors/habit'
-import { serializeHabitError } from '@/lib/errors/serializable'
 import { unarchiveHabit } from '@/lib/queries/habit'
-import { type HabitActionResult, requireOwnedHabit, requireUserId, revalidateHabitPaths } from './utils'
+import { type HabitActionResult, runHabitMutation } from './utils'
 
 /**
  * 習慣を復元するServer Action
@@ -13,25 +10,5 @@ import { type HabitActionResult, requireOwnedHabit, requireUserId, revalidateHab
  * @returns ServerActionResult<void, SerializableHabitError>
  */
 export async function unarchiveHabitAction(habitId: string): HabitActionResult {
-  const userIdResult = await requireUserId()
-
-  if (!userIdResult.ok) {
-    return userIdResult
-  }
-
-  const habitResult = await requireOwnedHabit(habitId, userIdResult.data)
-
-  if (!habitResult.ok) {
-    return habitResult
-  }
-
-  const unarchived = await unarchiveHabit(habitId, userIdResult.data)
-
-  if (!unarchived) {
-    return actionError(serializeHabitError(new NotFoundError()))
-  }
-
-  revalidateHabitPaths()
-
-  return actionOk()
+  return await runHabitMutation(habitId, unarchiveHabit)
 }

--- a/src/components/streak/DesktopDashboard.tsx
+++ b/src/components/streak/DesktopDashboard.tsx
@@ -2,28 +2,16 @@
 
 import { useState } from 'react'
 import type { IconName } from '@/components/basics/Icon'
-import type { OptimisticRollback } from '@/components/habits/types'
 import type { Period } from '@/constants/habit'
 import type { HabitPreset } from '@/constants/habit-data'
 import { filterHabitsByPeriod } from '@/lib/utils/habits'
-import type { HabitWithProgress } from '@/types/habit'
 import type { User } from '@/types/user'
 import { HabitForm } from './HabitForm'
 import { HabitListView } from './HabitListView'
+import type { DashboardBaseProps } from './types'
 
-interface DesktopDashboardProps {
-  habits: HabitWithProgress[]
-  pendingCheckins?: Set<string>
+interface DesktopDashboardProps extends DashboardBaseProps {
   user: User
-  onAddHabit: (
-    name: string,
-    icon: IconName,
-    options?: { color?: string | null; period?: Period; frequency?: number }
-  ) => Promise<void>
-  onToggleCheckin: (habitId: string) => Promise<void>
-  onArchiveOptimistic?: (habitId: string) => OptimisticRollback
-  onDeleteOptimistic?: (habitId: string) => OptimisticRollback
-  onResetOptimistic?: (habitId: string) => OptimisticRollback
 }
 
 type PeriodFilter = 'all' | Period

--- a/src/components/streak/StreakDashboard.tsx
+++ b/src/components/streak/StreakDashboard.tsx
@@ -4,7 +4,6 @@ import { Circle, LayoutGrid } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/basics/Button'
 import type { IconName } from '@/components/basics/Icon'
-import type { OptimisticRollback } from '@/components/habits/types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DEFAULT_DASHBOARD_VIEW } from '@/constants/dashboard'
 import type { Period } from '@/constants/habit'
@@ -12,24 +11,13 @@ import type { HabitPreset } from '@/constants/habit-data'
 import { cn } from '@/lib/utils'
 import { setClientCookie } from '@/lib/utils/cookies'
 import { filterHabitsByPeriod } from '@/lib/utils/habits'
-import type { HabitWithProgress } from '@/types/habit'
 import { HabitForm } from './HabitForm'
 import { HabitListView } from './HabitListView'
 import { HabitPresetSelector } from './HabitPresetSelector'
 import { HabitSimpleView } from './HabitSimpleView'
+import type { DashboardBaseProps } from './types'
 
-interface StreakDashboardProps {
-  habits: HabitWithProgress[]
-  pendingCheckins?: Set<string>
-  onAddHabit: (
-    name: string,
-    icon: IconName,
-    options?: { color?: string | null; period?: Period; frequency?: number }
-  ) => Promise<void>
-  onToggleCheckin: (habitId: string) => Promise<void>
-  onArchiveOptimistic?: (habitId: string) => OptimisticRollback
-  onDeleteOptimistic?: (habitId: string) => OptimisticRollback
-  onResetOptimistic?: (habitId: string) => OptimisticRollback
+interface StreakDashboardProps extends DashboardBaseProps {
   initialView?: MainView
 }
 

--- a/src/components/streak/types.ts
+++ b/src/components/streak/types.ts
@@ -1,0 +1,18 @@
+import type { IconName } from '@/components/basics/Icon'
+import type { OptimisticRollback } from '@/components/habits/types'
+import type { Period } from '@/constants/habit'
+import type { HabitWithProgress } from '@/types/habit'
+
+export interface DashboardBaseProps {
+  habits: HabitWithProgress[]
+  pendingCheckins?: Set<string>
+  onAddHabit: (
+    name: string,
+    icon: IconName,
+    options?: { color?: string | null; period?: Period; frequency?: number }
+  ) => Promise<void>
+  onToggleCheckin: (habitId: string) => Promise<void>
+  onArchiveOptimistic?: (habitId: string) => OptimisticRollback
+  onDeleteOptimistic?: (habitId: string) => OptimisticRollback
+  onResetOptimistic?: (habitId: string) => OptimisticRollback
+}


### PR DESCRIPTION
## 概要

similarity-ts の重複検出結果を踏まえて、習慣アクションの共通処理とダッシュボードの共通 Props を整理しました。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [x] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
