### PR TITLE
fix: guard auth timeouts

### DIFF
--- a/src/app/(dashboard)/@modal/(.)habits/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/@modal/(.)habits/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from 'next/navigation'
 import { HabitFormServer } from '@/components/habits/HabitFormServer'
 import { RouteModal } from '@/components/modals/RouteModal'
 import { SIGN_IN_PATH } from '@/constants/auth'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
 import { getHabitById } from '@/lib/queries/habit'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
@@ -14,7 +14,9 @@ export default async function EditHabitModalPage({ params }: HabitIdPageProps) {
 
   logInfo('request.habits.edit.modal:start', requestMeta)
 
-  const userId = await logSpan('habits.edit.modal.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
+  const userId = await logSpanOptional('habits.edit.modal.syncUser', () => getCurrentUserId(), requestMeta, {
+    timeoutMs,
+  })
 
   if (!userId) {
     logInfo('habits.edit.modal.syncUser:missing', requestMeta)

--- a/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
+++ b/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 import { HabitFormServer } from '@/components/habits/HabitFormServer'
 import { RouteModal } from '@/components/modals/RouteModal'
 import { SIGN_IN_PATH } from '@/constants/auth'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpanOptional } from '@/lib/logging'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
 
@@ -12,7 +12,9 @@ export default async function NewHabitModalPage() {
 
   logInfo('request.habits.new.modal:start', requestMeta)
 
-  const userId = await logSpan('habits.new.modal.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
+  const userId = await logSpanOptional('habits.new.modal.syncUser', () => getCurrentUserId(), requestMeta, {
+    timeoutMs,
+  })
 
   if (!userId) {
     logInfo('habits.new.modal.syncUser:missing', requestMeta)

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -7,7 +7,7 @@ import { Icon, type IconName } from '@/components/basics/Icon'
 import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card'
 import { SIGN_IN_PATH } from '@/constants/auth'
 import { PERIOD_DISPLAY_NAME, PERIODS, type Period } from '@/constants/habit'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
 import { getCheckinCountsByDateRange, getCheckinsByUserAndDate, getTotalCheckinsByUserId } from '@/lib/queries/checkin'
 import { getHabitsWithProgress } from '@/lib/queries/habit'
 import { getServerDateKey } from '@/lib/server/date'
@@ -38,7 +38,7 @@ export default async function AnalyticsPage() {
 
   logInfo('request.analytics:start', requestMeta)
 
-  const user = await logSpan('analytics.syncUser', () => syncUser(), requestMeta, { timeoutMs })
+  const user = await logSpanOptional('analytics.syncUser', () => syncUser(), requestMeta, { timeoutMs })
 
   if (!user) {
     logInfo('analytics.syncUser:missing', requestMeta)

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { SIGN_IN_PATH } from '@/constants/auth'
 import { DEFAULT_DASHBOARD_VIEW } from '@/constants/dashboard'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
 import { getCheckinsByUserAndDate } from '@/lib/queries/checkin'
 import { getHabitsWithProgress } from '@/lib/queries/habit'
 import { getServerDateKey } from '@/lib/server/date'
@@ -33,7 +33,7 @@ export default async function DashboardPage() {
 
   logInfo('request.dashboard:start', requestMeta)
 
-  const user = await logSpan('dashboard.syncUser', () => syncUser(), requestMeta, { timeoutMs })
+  const user = await logSpanOptional('dashboard.syncUser', () => syncUser(), requestMeta, { timeoutMs })
 
   if (!user) {
     logInfo('dashboard.syncUser:missing', requestMeta)

--- a/src/app/(dashboard)/habits/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/habits/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from 'next/navigation'
 import { HabitFormServer } from '@/components/habits/HabitFormServer'
 import { SIGN_IN_PATH } from '@/constants/auth'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
 import { getHabitById } from '@/lib/queries/habit'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
@@ -13,7 +13,9 @@ export default async function EditHabitPage({ params }: HabitIdPageProps) {
 
   logInfo('request.habits.edit.page:start', requestMeta)
 
-  const userId = await logSpan('habits.edit.page.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
+  const userId = await logSpanOptional('habits.edit.page.syncUser', () => getCurrentUserId(), requestMeta, {
+    timeoutMs,
+  })
 
   if (!userId) {
     logInfo('habits.edit.page.syncUser:missing', requestMeta)

--- a/src/app/(dashboard)/habits/new/page.tsx
+++ b/src/app/(dashboard)/habits/new/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { HabitFormServer } from '@/components/habits/HabitFormServer'
 import { SIGN_IN_PATH } from '@/constants/auth'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpanOptional } from '@/lib/logging'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
 
@@ -17,7 +17,7 @@ export default async function NewHabitPage() {
 
   logInfo('request.habits.new:start', requestMeta)
 
-  const userId = await logSpan('habits.new.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
+  const userId = await logSpanOptional('habits.new.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
 
   if (!userId) {
     logInfo('habits.new.syncUser:missing', requestMeta)

--- a/src/app/(dashboard)/habits/page.tsx
+++ b/src/app/(dashboard)/habits/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/basics/Button'
 import { Icon } from '@/components/basics/Icon'
 import { HabitTable } from '@/components/habits/HabitTable'
 import { SIGN_IN_PATH } from '@/constants/auth'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpanOptional } from '@/lib/logging'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
 
@@ -27,14 +27,14 @@ export default async function HabitsPage() {
 
   logInfo('request.habits:start', requestMeta)
 
-  const clerkUser = await logSpan('habits.clerkUser', () => currentUser(), requestMeta, { timeoutMs })
+  const clerkUser = await logSpanOptional('habits.clerkUser', () => currentUser(), requestMeta, { timeoutMs })
 
   if (!clerkUser) {
     logInfo('habits.clerkUser:missing', requestMeta)
     redirect(SIGN_IN_PATH)
   }
 
-  const userId = await logSpan('habits.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
+  const userId = await logSpanOptional('habits.syncUser', () => getCurrentUserId(), requestMeta, { timeoutMs })
 
   if (!userId) {
     logInfo('habits.syncUser:missing', requestMeta)

--- a/src/app/actions/habits/checkin.ts
+++ b/src/app/actions/habits/checkin.ts
@@ -5,7 +5,7 @@ import { weekStartToDay } from '@/constants/habit'
 import { DEFAULT_REQUEST_TIMEOUT_MS } from '@/constants/request-timeout'
 import { toActionResult } from '@/lib/actions/result'
 import { AuthorizationError, UnauthorizedError } from '@/lib/errors/habit'
-import { createRequestMeta, logInfo, logSpan } from '@/lib/logging'
+import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
 import { createCheckin } from '@/lib/queries/checkin'
 import { getCheckinCountForPeriod, getHabitById } from '@/lib/queries/habit'
 import { getUserWeekStartById } from '@/lib/queries/user'
@@ -24,10 +24,11 @@ export async function addCheckinAction(habitId: string, dateKey?: string): Habit
         'action.habits.checkin',
         async () => {
           // 認証チェック
-          const userId = await logSpanWithTimeout(
+          const userId = await logSpanOptional(
             'action.habits.checkin.getCurrentUserId',
             () => getCurrentUserId(),
-            baseMeta
+            baseMeta,
+            { timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS }
           )
           if (!userId) {
             throw new UnauthorizedError({ detail: '認証されていません' })


### PR DESCRIPTION
## 概要

認証関連のリクエストでタイムアウトが発生した場合に、500 で落とさずサインインへ戻すようにしました。チェックインの Server Action もタイムアウト時は未認証扱いで早期終了します。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [x] API / Server Actions
- [ ] データベース (Prisma)
- [x] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
