### PR TITLE
chore: dedupe formatError

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,18 +1,11 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import * as schema from '@/db/schema'
-import { logError, logInfo } from '@/lib/logging'
+import { formatError, logError, logInfo } from '@/lib/logging'
 import { safeParseCloudflareEnvBindings } from '@/schemas/cloudflare'
 
 function isWorkersRuntime(): boolean {
   return typeof globalThis !== 'undefined' && 'caches' in globalThis
-}
-
-function formatError(error: unknown): { name: string; message: string } {
-  if (error instanceof Error) {
-    return { name: error.name, message: error.message }
-  }
-  return { name: 'UnknownError', message: String(error) }
 }
 
 function normalizeConnectionString(raw: string): string {

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -55,7 +55,7 @@ function nowMs(): number {
   return Date.now()
 }
 
-function formatError(error: unknown): { name: string; message: string } {
+export function formatError(error: unknown): { name: string; message: string } {
   if (error instanceof Error) {
     return { name: error.name, message: error.message }
   }


### PR DESCRIPTION
## 概要

`src/lib/db.ts` の重複していた `formatError` を削除し、`src/lib/logging.ts` の共通関数を再利用するようにしました。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [x] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- なし -->

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
