### PR TITLE
feat: improve settings UI

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -23,12 +23,14 @@ export default async function SettingsPage() {
 
   return (
     <div className="flex flex-1 flex-col gap-6 p-6">
-      <div className="space-y-2">
-        <h1 className="font-bold text-3xl text-foreground">設定</h1>
+      <header className="space-y-2">
+        <h1 className="text-balance font-bold text-3xl text-foreground">設定</h1>
         <p className="text-muted-foreground">アプリの表示をカスタマイズできます。</p>
-      </div>
-      <ThemeSettings initialColorTheme={initialColorTheme} />
-      <WeekStartSettings />
+      </header>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <ThemeSettings initialColorTheme={initialColorTheme} />
+        <WeekStartSettings />
+      </section>
     </div>
   )
 }

--- a/src/components/settings/ThemeSettings.tsx
+++ b/src/components/settings/ThemeSettings.tsx
@@ -4,9 +4,28 @@ import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { ColorPalette } from '@/components/streak/ColorPalette'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { type ColorThemeName, DEFAULT_THEME_MODE } from '@/constants/theme'
 import { useColorTheme } from '@/hooks/use-color-theme'
+
+const MODE_LABELS = {
+  light: 'ライト',
+  dark: 'ダーク',
+  system: 'システム',
+} as const
+
+const COLOR_THEME_META: Record<ColorThemeName, { label: string; swatch: string }> = {
+  teal: { label: 'ティール', swatch: 'var(--teal-9)' },
+  lime: { label: 'ライム', swatch: 'var(--lime-9)' },
+  orange: { label: 'オレンジ', swatch: 'var(--orange-9)' },
+  red: { label: 'レッド', swatch: 'var(--red-9)' },
+  pink: { label: 'ピンク', swatch: 'var(--pink-9)' },
+  purple: { label: 'パープル', swatch: 'var(--purple-9)' },
+  blue: { label: 'ブルー', swatch: 'var(--blue-9)' },
+  cyan: { label: 'シアン', swatch: 'var(--cyan-9)' },
+  yellow: { label: 'イエロー', swatch: 'var(--yellow-9)' },
+}
 
 export function ThemeSettings({ initialColorTheme }: { initialColorTheme?: ColorThemeName }) {
   const { theme: mode, setTheme: setMode } = useTheme()
@@ -18,18 +37,23 @@ export function ThemeSettings({ initialColorTheme }: { initialColorTheme?: Color
   }, [])
 
   const currentMode = mounted ? (mode ?? DEFAULT_THEME_MODE) : DEFAULT_THEME_MODE
+  const currentModeLabel = MODE_LABELS[currentMode as keyof typeof MODE_LABELS] ?? MODE_LABELS.system
+  const currentColorMeta = COLOR_THEME_META[colorTheme]
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>テーマ設定</CardTitle>
-        <CardDescription>ダークモードとアクセントカラーを変更します。</CardDescription>
+        <CardDescription>ダークモードとアクセントカラーを変更します。変更内容は自動で保存されます。</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="space-y-2">
-          <p className="font-medium text-foreground">表示モード</p>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-medium text-foreground">表示モード</p>
+            <span className="text-muted-foreground text-xs">現在: {currentModeLabel}</span>
+          </div>
           <Tabs onValueChange={(value) => setMode(value)} value={currentMode}>
-            <TabsList className="w-full">
+            <TabsList aria-label="表示モード" className="grid w-full grid-cols-3">
               <TabsTrigger className="flex-1" value="light">
                 ライト
               </TabsTrigger>
@@ -41,14 +65,26 @@ export function ThemeSettings({ initialColorTheme }: { initialColorTheme?: Color
               </TabsTrigger>
             </TabsList>
           </Tabs>
+          <p className="text-muted-foreground text-xs">システムはOSの設定に合わせます。</p>
         </div>
-        <div className="space-y-2">
-          <p className="font-medium text-foreground">アクセントカラー</p>
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="font-medium text-foreground">アクセントカラー</p>
+            <span className="inline-flex items-center gap-2 rounded-full bg-muted px-2.5 py-1 text-muted-foreground text-xs">
+              <span
+                aria-hidden="true"
+                className="h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: currentColorMeta.swatch }}
+              />
+              現在: {currentColorMeta.label}
+            </span>
+          </div>
           {ready ? (
             <ColorPalette currentTheme={colorTheme} onThemeChange={setColorTheme} />
           ) : (
-            <div className="h-8 w-44 rounded-full bg-muted" />
+            <Skeleton className="h-8 w-44 rounded-full motion-reduce:animate-none" />
           )}
+          <p className="text-muted-foreground text-xs">チェックインやカードの強調色に反映されます。</p>
         </div>
       </CardContent>
     </Card>

--- a/src/components/settings/WeekStartSettings.tsx
+++ b/src/components/settings/WeekStartSettings.tsx
@@ -5,9 +5,16 @@ import { updateWeekStartAction } from '@/app/actions/settings/updateWeekStart'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Skeleton } from '@/components/ui/skeleton'
 import type { WeekStart } from '@/constants/habit'
 import { useWeekStart } from '@/hooks/use-week-start'
+import { cn } from '@/lib/utils'
 import { appToast } from '@/lib/utils/toast'
+
+const WEEK_START_OPTIONS: Array<{ value: WeekStart; label: string; description: string }> = [
+  { value: 'monday', label: '月曜日', description: '週次集計を月曜起点で計算します。' },
+  { value: 'sunday', label: '日曜日', description: 'カレンダー表示に合わせた週の区切りです。' },
+]
 
 export function WeekStartSettings() {
   const { weekStart, setWeekStart, ready } = useWeekStart()
@@ -37,23 +44,47 @@ export function WeekStartSettings() {
     <Card>
       <CardHeader>
         <CardTitle>週の開始日</CardTitle>
-        <CardDescription>カレンダー表示の週の開始日を変更します。</CardDescription>
+        <CardDescription>カレンダー表示と週次集計の基準を変更します。</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-3">
         {ready ? (
-          <RadioGroup disabled={isUpdating} onValueChange={handleWeekStartChange} value={weekStart}>
-            <div className="flex items-center space-x-2">
-              <RadioGroupItem id="monday" value="monday" />
-              <Label htmlFor="monday">月曜日</Label>
-            </div>
-            <div className="flex items-center space-x-2">
-              <RadioGroupItem id="sunday" value="sunday" />
-              <Label htmlFor="sunday">日曜日</Label>
-            </div>
+          <RadioGroup
+            className="grid gap-3"
+            disabled={isUpdating}
+            onValueChange={handleWeekStartChange}
+            value={weekStart}
+          >
+            {WEEK_START_OPTIONS.map((option) => {
+              const isSelected = weekStart === option.value
+              return (
+                <Label
+                  aria-disabled={isUpdating}
+                  className={cn(
+                    'flex w-full cursor-pointer items-start gap-3 rounded-lg border border-border/60 bg-background p-3 font-normal text-sm leading-normal transition-colors',
+                    'hover:border-foreground/40 hover:bg-muted/30',
+                    'focus-within:border-primary/70 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background',
+                    isSelected && 'border-primary/60 bg-primary/5',
+                    isUpdating && 'cursor-not-allowed opacity-70'
+                  )}
+                  htmlFor={option.value}
+                  key={option.value}
+                >
+                  <RadioGroupItem className="mt-1" id={option.value} value={option.value} />
+                  <div className="space-y-1">
+                    <p className="font-medium text-foreground">{option.label}</p>
+                    <p className="text-muted-foreground text-sm leading-relaxed">{option.description}</p>
+                  </div>
+                </Label>
+              )
+            })}
           </RadioGroup>
         ) : (
-          <div className="h-20 w-full rounded bg-muted" />
+          <div className="space-y-3">
+            <Skeleton className="h-16 w-full rounded-lg motion-reduce:animate-none" />
+            <Skeleton className="h-16 w-full rounded-lg motion-reduce:animate-none" />
+          </div>
         )}
+        <p className="text-muted-foreground text-xs">変更内容はすぐに保存されます。</p>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## 概要
- /settings のレイアウトを整え、カードを2カラムで配置
- 表示モード/アクセントカラーの現在値を明示し、補足テキストを追加
- 週の開始日を選択カード化してタップ領域と説明を改善、スケルトンの動きを抑制

## 種別
- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

## 確認済み
- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

実行: `mise run ci`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
