### PR TITLE
perf: dedupe useIsMobile subscriptions

### DIFF
--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,19 +1,49 @@
 import * as React from 'react'
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+let mediaQueryList: MediaQueryList | null = null
+const subscribers = new Set<() => void>()
+
+const getMediaQueryList = () => {
+  if (mediaQueryList) {
+    return mediaQueryList
+  }
+  if (typeof window === 'undefined' || !('matchMedia' in window)) {
+    return null
+  }
+  mediaQueryList = window.matchMedia(MOBILE_QUERY)
+  return mediaQueryList
+}
+
+const notifySubscribers = () => {
+  for (const callback of subscribers) {
+    callback()
+  }
+}
+
+const subscribe = (callback: () => void) => {
+  const mql = getMediaQueryList()
+  if (!mql) {
+    return () => undefined
+  }
+
+  subscribers.add(callback)
+  if (subscribers.size === 1) {
+    mql.addEventListener('change', notifySubscribers)
+  }
+
+  return () => {
+    subscribers.delete(callback)
+    if (subscribers.size === 0) {
+      mql.removeEventListener('change', notifySubscribers)
+    }
+  }
+}
+
+const getSnapshot = () => getMediaQueryList()?.matches ?? false
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean>(false)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener('change', onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
 }


### PR DESCRIPTION
## 概要

- `useIsMobile` の購読を共有ストア化して、コンポーネントごとの `matchMedia` リスナー登録を一本化
- `useSyncExternalStore` で購読とスナップショット取得を一元化
- 実行: `mise ci`

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
