### PR TITLE
fix: avoid caching Next assets in service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,6 @@
-const CACHE_NAME = 'keepon-v1'
+const CACHE_NAME = 'keepon-v2'
 const OFFLINE_URL = '/offline'
+const NEXT_ASSET_PREFIX = '/_next/'
 
 const PRECACHE_FILES = ['/', '/offline', '/manifest.json', '/icon-192.png', '/icon-512.png']
 
@@ -20,6 +21,11 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const { request } = event
   const url = new URL(request.url)
+
+  // Next.js ビルド成果物は常にネットワーク優先（Server ActionsのID不一致を回避）
+  if (url.pathname.startsWith(NEXT_ASSET_PREFIX)) {
+    return
+  }
 
   // API・認証: network-only (SWスルー)
   if (


### PR DESCRIPTION
## 概要
- Service Worker が `/_next/` 配下のビルド成果物をキャッシュしないように変更
- キャッシュ名を更新して既存キャッシュを確実に破棄

## 種別
- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [x] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue
- 

## 確認済み
- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

テスト: 未実施
