### PR TITLE
fix: precache offline CSS for service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,45 @@
-const CACHE_NAME = 'keepon-v2'
+const CACHE_NAME = 'keepon-v3'
 const OFFLINE_URL = '/offline'
 const NEXT_ASSET_PREFIX = '/_next/'
+const NEXT_STATIC_PREFIX = '/_next/static/'
+const NEXT_STATIC_CSS_PREFIX = '/_next/static/css/'
+const NEXT_STATIC_MEDIA_PREFIX = '/_next/static/media/'
 
 const PRECACHE_FILES = ['/', '/offline', '/manifest.json', '/icon-192.png', '/icon-512.png']
 
+const extractOfflineAssets = (html) => {
+  const assets = new Set()
+  const pattern = /["'](\/_next\/static\/[^"']+\.(?:css|woff2?|ttf|otf|eot))["']/g
+  let match = pattern.exec(html)
+  while (match) {
+    assets.add(match[1])
+    match = pattern.exec(html)
+  }
+  return Array.from(assets)
+}
+
+const precacheOfflineAssets = async (cache) => {
+  try {
+    const response = await fetch(OFFLINE_URL, { cache: 'no-store' })
+    const html = await response.clone().text()
+    await cache.put(OFFLINE_URL, response)
+    const assets = extractOfflineAssets(html)
+    if (assets.length > 0) {
+      await cache.addAll(assets)
+    }
+  } catch {
+    // オフライン用の追加プリキャッシュは失敗しても致命的ではない
+  }
+}
+
 // インストール時: プリキャッシュ
 self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_FILES)))
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      await cache.addAll(PRECACHE_FILES)
+      await precacheOfflineAssets(cache)
+    })
+  )
 })
 
 // アクティベート時: 古いキャッシュ削除
@@ -22,9 +55,13 @@ self.addEventListener('fetch', (event) => {
   const { request } = event
   const url = new URL(request.url)
 
-  // Next.js ビルド成果物は常にネットワーク優先（Server ActionsのID不一致を回避）
+  // Next.js ビルド成果物は基本ネットワーク優先（Server ActionsのID不一致を回避）
   if (url.pathname.startsWith(NEXT_ASSET_PREFIX)) {
-    return
+    const isAllowedStatic =
+      url.pathname.startsWith(NEXT_STATIC_CSS_PREFIX) || url.pathname.startsWith(NEXT_STATIC_MEDIA_PREFIX)
+    if (!isAllowedStatic) {
+      return
+    }
   }
 
   // API・認証: network-only (SWスルー)


### PR DESCRIPTION
## 概要
- オフラインページのHTMLから `/_next/static/*.css` を抽出してプリキャッシュ
- `/_next/static/css` と `/_next/static/media` のみ SW のキャッシュ対象に許可
- `/_next/static/chunks` などJSは引き続きネットワーク優先で、Server Actions ID不一致を回避

## 種別
- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [x] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue
- 

## 確認済み
- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

テスト:
- `dotenvx run -- pnpm test:run`
(注) `pnpm env:run -- pnpm test:run` は `env:run` の `--` 二重化で失敗
