### PR TITLE
fix: avoid stale HTML cache and fallback on habits timeout

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,10 +7,26 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: '/:path*',
+        headers: [
+          { key: 'Cache-Control', value: 'no-store, max-age=0' },
+          { key: 'CDN-Cache-Control', value: 'no-store' },
+          { key: 'Pragma', value: 'no-cache' },
+        ],
+      },
+      {
+        source: '/_next/static/:path*',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+          { key: 'CDN-Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
+      {
         source: '/manifest.json',
         headers: [
           { key: 'Content-Type', value: 'application/manifest+json' },
           { key: 'Cache-Control', value: 'public, max-age=86400' },
+          { key: 'CDN-Cache-Control', value: 'public, max-age=86400' },
         ],
       },
       {
@@ -18,6 +34,7 @@ const nextConfig: NextConfig = {
         headers: [
           { key: 'Content-Type', value: 'application/javascript' },
           { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
+          { key: 'CDN-Cache-Control', value: 'public, max-age=0, must-revalidate' },
           { key: 'Service-Worker-Allowed', value: '/' },
         ],
       },


### PR DESCRIPTION
## 概要
- HTMLレスポンスに `Cache-Control: no-store` を付与し、Cloudflare/CDNのキャッシュによるServer Action ID不一致を抑制
- `/_next/static` は長期キャッシュを維持
- DBタイムアウト時に直近の習慣キャッシュ（期限切れでも）へフォールバックし、ダッシュボードの500を回避

## 種別
- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [x] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue
- 

## 確認済み
- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

テスト:
- `dotenvx run -- pnpm test:run`
