### PR TITLE
Fallback to stale habit cache

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -46,7 +46,9 @@ export default async function DashboardPage() {
   }
 
   const cacheSnapshot = await getHabitsCacheSnapshot(user.id)
-  const staleHabits = cacheSnapshot && cacheSnapshot.dateKey !== dateKey ? cacheSnapshot.habits : null
+  const isStale =
+    cacheSnapshot && (cacheSnapshot.staleAt || cacheSnapshot.dateKey !== dateKey)
+  const staleHabits = isStale ? cacheSnapshot.habits : null
 
   let habits: HabitWithProgress[]
   try {

--- a/src/lib/queries/habit.ts
+++ b/src/lib/queries/habit.ts
@@ -354,12 +354,17 @@ export async function getHabitsWithProgress(
   let staleSnapshot: typeof cacheSnapshot | null = null
 
   if (cacheSnapshot) {
-    if (cacheSnapshot.dateKey === dateKey) {
+    if (!cacheSnapshot.staleAt && cacheSnapshot.dateKey === dateKey) {
       logInfo('getHabitsWithProgress:cache-hit', { userId, dateKey })
       return cacheSnapshot.habits
     }
     staleSnapshot = cacheSnapshot
-    logInfo('habit-cache:stale', { userId, cachedDateKey: cacheSnapshot.dateKey, requestedDateKey: dateKey })
+    logInfo('habit-cache:stale', {
+      userId,
+      cachedDateKey: cacheSnapshot.dateKey,
+      requestedDateKey: dateKey,
+      reason: cacheSnapshot.staleAt ? 'invalidated' : 'date-key',
+    })
   } else {
     logInfo('habit-cache:miss', { userId })
   }

--- a/src/schemas/cache.ts
+++ b/src/schemas/cache.ts
@@ -17,6 +17,7 @@ export const HabitsCacheDataSchema = v.object({
   habits: v.array(v.any()), // HabitWithProgress は複雑な型なので any で許容
   dateKey: v.string(),
   timestamp: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  staleAt: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
 })
 
 export type HabitsCacheDataSchemaType = v.InferOutput<typeof HabitsCacheDataSchema>


### PR DESCRIPTION
## Summary
- retain habit cache as stale data on invalidation to allow fallback during DB timeouts
- align /habits date key with dashboard timezone and add stale fallback for habits table
- treat invalidated cache as stale for dashboard retrieval

## Testing
- dotenvx run -- pnpm test:run