### PR TITLE
Bypass Clerk handshake in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
 
 const isPublicRoute = createRouteMatcher([
   '/',
@@ -10,8 +11,12 @@ const isPublicRoute = createRouteMatcher([
 ])
 
 export default clerkMiddleware(async (auth, request) => {
+  if (request.nextUrl.searchParams.has('__clerk_handshake')) {
+    // Clerk ハンドシェイクは認証保護をスキップしてリダイレクトループを回避
+    return NextResponse.next()
+  }
   if (!isPublicRoute(request)) {
-    await auth.protect()
+    return auth.protect()
   }
 })
 


### PR DESCRIPTION
## Summary
- allow Clerk handshake query requests to bypass auth protection to avoid redirect loops

## Testing
- dotenvx run -- pnpm test:run