### PR TITLE
Fix Clerk middleware return

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,8 +16,9 @@ export default clerkMiddleware(async (auth, request) => {
     return NextResponse.next()
   }
   if (!isPublicRoute(request)) {
-    return auth.protect()
+    await auth.protect()
   }
+  return NextResponse.next()
 })
 
 export const config = {


### PR DESCRIPTION
## Summary
- return NextResponse after auth.protect() to satisfy Clerk middleware typing and build

## Testing
- dotenvx run -- pnpm test:run
- pnpm build:cf