### PR TITLE
Pass Clerk keys to middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher, type ClerkMiddlewareOptions } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 
 const isPublicRoute = createRouteMatcher([
@@ -19,7 +19,7 @@ export default clerkMiddleware(async (auth, request) => {
     await auth.protect()
   }
   return NextResponse.next()
-})
+}, getClerkMiddlewareOptions())
 
 export const config = {
   matcher: [
@@ -28,4 +28,12 @@ export const config = {
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
+}
+
+function getClerkMiddlewareOptions(): ClerkMiddlewareOptions {
+  return {
+    publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    signInUrl: process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
+    signUpUrl: process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL,
+  }
 }


### PR DESCRIPTION
## Summary
- pass publishable key and sign-in/up URLs into clerkMiddleware options to align runtime keys

## Testing
- dotenvx run -- pnpm test:run
- pnpm build:cf