### PR TITLE
Fix service worker auto registration

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@ const NEXT_STATIC_PREFIX = '/_next/static/'
 const NEXT_STATIC_CSS_PREFIX = '/_next/static/css/'
 const NEXT_STATIC_MEDIA_PREFIX = '/_next/static/media/'
 
-const PRECACHE_FILES = ['/', '/offline', '/manifest.json', '/icon-192.png', '/icon-512.png']
+const PRECACHE_FILES = ['/offline', '/manifest.json', '/icon-192.png', '/icon-512.png']
 
 const extractOfflineAssets = (html) => {
   const assets = new Set()
@@ -36,7 +36,7 @@ const precacheOfflineAssets = async (cache) => {
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(async (cache) => {
-      await cache.addAll(PRECACHE_FILES)
+      await Promise.all(PRECACHE_FILES.map((file) => cache.add(file).catch(() => undefined)))
       await precacheOfflineAssets(cache)
     })
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,33 @@ export const viewport: Viewport = {
   initialScale: 1,
 }
 
+const nameHelperScript = `
+(function() {
+  try {
+    var globalRef = typeof globalThis !== 'undefined' ? globalThis : window;
+    if (typeof globalRef.__name !== 'function') {
+      globalRef.__name = function(target, name) {
+        try {
+          Object.defineProperty(target, 'name', { value: name, configurable: true });
+        } catch (e) {}
+        return target;
+      };
+    }
+  } catch (e) {}
+})();
+`
+
+const swRegistrationScript = `
+(function() {
+  try {
+    if (!('serviceWorker' in navigator)) return;
+    if (window.__swRegistering) return;
+    window.__swRegistering = true;
+    navigator.serviceWorker.register('/sw.js').catch(function() {});
+  } catch (e) {}
+})();
+`
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -64,6 +91,10 @@ export default async function RootLayout({
           <meta content="light dark" name="color-scheme" />
           <meta content={THEME_COLOR_LIGHT} name="theme-color" />
           <meta content={THEME_COLOR_DARK} media="(prefers-color-scheme: dark)" name="theme-color" />
+          <script dangerouslySetInnerHTML={{ __html: nameHelperScript }} />
+          {process.env.NODE_ENV === 'production' ? (
+            <script dangerouslySetInnerHTML={{ __html: swRegistrationScript }} />
+          ) : null}
           <ThemeModeScript />
           <ColorThemeScript />
         </head>


### PR DESCRIPTION
## Summary
- add client-side fallback to register the service worker in production
- prevent SW install failures by avoiding / precache and ignoring individual precache errors
- define a global __name helper to avoid inline script errors before hydration

## Testing
- pnpm test:run
- pnpm build:cf
- pnpm cf:deploy
- agent-browser (prod): SW registration auto-enabled + offline page styled