### PR TITLE
refactor: reduce duplication in habits flow

### DIFF
--- a/src/app/actions/habits/checkin.ts
+++ b/src/app/actions/habits/checkin.ts
@@ -6,7 +6,7 @@ import { toActionResult } from '@/lib/actions/result'
 import { resetDb } from '@/lib/db'
 import { AuthorizationError, UnauthorizedError } from '@/lib/errors/habit'
 import { createRequestMeta, isTimeoutError, logInfo, logSpan, logSpanOptional, logWarn } from '@/lib/logging'
-import { createCheckinWithLimit } from '@/lib/queries/checkin'
+import { type CreateCheckinWithLimitResult, createCheckinWithLimit } from '@/lib/queries/checkin'
 import { getHabitById } from '@/lib/queries/habit'
 import { getUserWeekStartById } from '@/lib/queries/user'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
@@ -95,10 +95,7 @@ async function resolveWeekStartDay(
   return weekStartToDay(weekStart)
 }
 
-interface CheckinResultData {
-  created: boolean
-  currentCount: number
-}
+type CheckinResultData = Pick<CreateCheckinWithLimitResult, 'created' | 'currentCount'>
 
 async function performCheckin(params: {
   habitId: string

--- a/src/components/streak/ColorPalette.tsx
+++ b/src/components/streak/ColorPalette.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/basics/Button'
 import type { ColorThemeName } from '@/constants/theme'
 import { cn } from '@/lib/utils'
 
-interface ColorPaletteProps {
+export interface ColorPaletteProps {
   currentTheme: ColorThemeName
   onThemeChange: (theme: ColorThemeName) => void
 }

--- a/src/components/streak/StreakToolbar.tsx
+++ b/src/components/streak/StreakToolbar.tsx
@@ -10,13 +10,10 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '@/components/ui/drawer'
-import type { ColorThemeName } from '@/constants/theme'
 import { cn } from '@/lib/utils'
-import { ColorPalette } from './ColorPalette'
+import { ColorPalette, type ColorPaletteProps } from './ColorPalette'
 
-interface StreakToolbarProps {
-  currentTheme: ColorThemeName
-  onThemeChange: (theme: ColorThemeName) => void
+interface StreakToolbarProps extends ColorPaletteProps {
   ready: boolean
 }
 

--- a/src/lib/queries/checkin.ts
+++ b/src/lib/queries/checkin.ts
@@ -19,7 +19,7 @@ interface CreateCheckinWithLimitInput {
   weekStartDay?: WeekStartDay
 }
 
-interface CreateCheckinWithLimitResult {
+export interface CreateCheckinWithLimitResult {
   created: boolean
   currentCount: number
   checkin: typeof checkins.$inferSelect | null

--- a/src/validators/habit.ts
+++ b/src/validators/habit.ts
@@ -14,6 +14,14 @@ export type HabitInput = Omit<InferInsertModel<typeof import('@/db/schema').habi
  */
 export type HabitUpdateInput = Partial<HabitInput>
 
+const toValidationError = (issues: ReturnType<typeof safeParseHabitInput>['issues']) => {
+  const firstIssue = issues?.[0]
+  return new ValidationError({
+    field: firstIssue?.path?.map((p) => String(p.key)).join('.') || 'unknown',
+    reason: firstIssue?.message || 'Validation failed',
+  })
+}
+
 /**
  * FormDataから習慣入力をバリデーション
  *
@@ -26,13 +34,7 @@ export function validateHabitInput(userId: string, formData: FormData): Result.R
   const parseResult = safeParseHabitInput(transformed)
 
   if (!parseResult.success) {
-    const firstIssue = parseResult.issues[0]
-    return Result.fail(
-      new ValidationError({
-        field: firstIssue?.path?.map((p) => p.key).join('.') || 'unknown',
-        reason: firstIssue?.message || 'Validation failed',
-      })
-    )
+    return Result.fail(toValidationError(parseResult.issues))
   }
 
   return Result.succeed({
@@ -57,13 +59,7 @@ export function validateHabitUpdate(formData: FormData): Result.Result<HabitUpda
   const parseResult = safeParseHabitInput(transformed)
 
   if (!parseResult.success) {
-    const firstIssue = parseResult.issues[0]
-    return Result.fail(
-      new ValidationError({
-        field: firstIssue?.path?.map((p) => p.key).join('.') || 'unknown',
-        reason: firstIssue?.message || 'Validation failed',
-      })
-    )
+    return Result.fail(toValidationError(parseResult.issues))
   }
 
   return Result.succeed(parseResult.output)


### PR DESCRIPTION
## 概要
- 習慣の進捗更新ロジックを共通化
- 習慣バリデーションのエラー生成を共通化
- チェックイン結果型とカラー選択Propsを共有型として再利用

## 種別
- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [x] フロントエンド
- [x] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue
- なし

## 確認済み
- [ ] 動作確認完了
- [ ] 品質チェック通過 ([lint:biome] 
[lint:biome] > keep-on@0.1.0 lint /home/j138/src/github.com/jey3dayo/keep-on
[lint:biome] > ultracite check
[lint:biome] 
[format] 
[format] > keep-on@0.1.0 format /home/j138/src/github.com/jey3dayo/keep-on
[format] > ultracite fix
[format] 
[lint:md] markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
[lint:md] Finding: ${MD_GLOB} !**/node_modules/** !**/.worktrees/** **/*.md !node_modules !.next !.open-next !out !src/generated !.worktrees
[lint:md] Linting: 20 file(s)
[lint:md] Summary: 0 error(s)
[lint:biome] Checked 239 files in 129ms. No fixes applied.
[format] Checked 239 files in 244ms. No fixes applied.
[format] markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
[format] Finding: ${MD_GLOB} !**/node_modules/** !**/.worktrees/** **/*.md !node_modules !.next !.open-next !out !src/generated !.worktrees
[format] Linting: 20 file(s)
[format] Summary: 0 error(s))
- [ ] Cloudflare ビルド確認 (
> keep-on@0.1.0 build:cf /home/j138/src/github.com/jey3dayo/keep-on
> dotenvx run -- opennextjs-cloudflare build

[dotenvx@1.52.0] injecting env (0) from .env

┌─────────────────────────────┐
│ OpenNext — Cloudflare build │
└─────────────────────────────┘

App directory: /home/j138/src/github.com/jey3dayo/keep-on
Next.js version : 16.1.6
@opennextjs/cloudflare version: 1.16.1
@opennextjs/aws version: 3.9.14

┌─────────────────────────────────┐
│ OpenNext — Building Next.js app │
└─────────────────────────────────┘


> keep-on@0.1.0 build /home/j138/src/github.com/jey3dayo/keep-on
> dotenvx run -- next build

[dotenvx@1.52.0] injecting env (0) from .env
▲ Next.js 16.1.6 (Turbopack)
- Environments: .env
- Experiments (use with caution):
  · optimizePackageImports

  Creating an optimized production build ...
✓ Compiled successfully in 6.1s
  Running TypeScript ...
  Collecting page data using 11 workers ...
  Generating static pages using 11 workers (0/14) ...
request.habits.new.modal:start {"route":"/habits/new","requestId":"01470186-ed7a-4fd1-9b0a-3a4dc1f91016"}
habits.new.modal.syncUser:start {"route":"/habits/new","requestId":"01470186-ed7a-4fd1-9b0a-3a4dc1f91016"}
request.habits.new:start {"route":"/habits/new","requestId":"46278d62-be18-4c5a-96a6-d9e9c5b67996"}
habits.new.syncUser:start {"route":"/habits/new","requestId":"46278d62-be18-4c5a-96a6-d9e9c5b67996"}
request.analytics:start {"route":"/analytics","requestId":"303b9c1d-7c08-4fb0-807f-04b1a548ffe9"}
analytics.syncUser:start {"route":"/analytics","requestId":"303b9c1d-7c08-4fb0-807f-04b1a548ffe9"}
  Generating static pages using 11 workers (3/14) 
request.habits:start {"route":"/habits","requestId":"82f0cb86-5ead-49ba-b6b7-19fc3010b3e7"}
habits.clerkUser:start {"route":"/habits","requestId":"82f0cb86-5ead-49ba-b6b7-19fc3010b3e7"}
  Generating static pages using 11 workers (6/14) 
  Generating static pages using 11 workers (10/14) 
✓ Generating static pages using 11 workers (14/14) in 155.7ms
  Finalizing page optimization ...

Route (app)
┌ ƒ /
├ ƒ /_not-found
├ ƒ /(.)habits/[id]/edit
├ ƒ /(.)habits/new
├ ƒ /analytics
├ ƒ /dashboard
├ ƒ /debug/repro-concurrency
├ ƒ /habits
├ ƒ /habits/[id]/edit
├ ƒ /habits/new
├ ƒ /health
├ ƒ /help
├ ○ /icon.png
├ ○ /manifest.webmanifest
├ ƒ /offline
├ ƒ /settings
├ ƒ /sign-in/[[...sign-in]]
└ ƒ /sign-up/[[...sign-up]]


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand


┌──────────────────────────────┐
│ OpenNext — Generating bundle │
└──────────────────────────────┘

Bundling middleware function...
Bundling static assets...
Bundling cache assets...
Building server function: default...
Applying code patches: 1.608s
# copyPackageTemplateFiles
[35m⚙️ Bundling the OpenNext server...
[0m
[35mWorker saved in `.open-next/worker.js` 🚀
[0m
OpenNext build complete.)
- [ ] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時:  を暗号化 (
> keep-on@0.1.0 env:encrypt /home/j138/src/github.com/jey3dayo/keep-on
> dotenvx encrypt

derived public key (02a2425…) does not match the existing public key (031793f…)
debug info: DOTENV_PRIVATE_KEY=8782973… (derived DOTENV_PUBLIC_KEY=02a2425… vs existing DOTENV_PUBLIC_KEY=031793f…))

テスト: [format] 
[format] > keep-on@0.1.0 format /home/j138/src/github.com/jey3dayo/keep-on
[format] > ultracite fix
[format] 
[lint:md] markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
[lint:md] Finding: ${MD_GLOB} !**/node_modules/** !**/.worktrees/** **/*.md !node_modules !.next !.open-next !out !src/generated !.worktrees
[lint:md] Linting: 20 file(s)
[lint:md] Summary: 0 error(s)
[format] Checked 239 files in 195ms. No fixes applied.
[format] markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
[format] Finding: ${MD_GLOB} !**/node_modules/** !**/.worktrees/** **/*.md !node_modules !.next !.open-next !out !src/generated !.worktrees
[format] Linting: 20 file(s)
[format] Summary: 0 error(s)

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->