### PR TITLE
feat: update recommended frequency for habit presets

### DIFF
--- a/src/constants/habit-data.ts
+++ b/src/constants/habit-data.ts
@@ -202,7 +202,7 @@ export const habitPresets: HabitPreset[] = [
     iconId: 'droplets',
     colorId: 'cyan',
     period: 'daily',
-    frequency: 1,
+    frequency: 8,
     category: 'health',
   },
   {
@@ -248,7 +248,7 @@ export const habitPresets: HabitPreset[] = [
     iconId: 'clock',
     colorId: 'red',
     period: 'daily',
-    frequency: 1,
+    frequency: 4,
     category: 'productivity',
   },
   {
@@ -293,7 +293,7 @@ export const habitPresets: HabitPreset[] = [
     iconId: 'camera',
     colorId: 'pink',
     period: 'daily',
-    frequency: 1,
+    frequency: 3,
     category: 'lifestyle',
   },
   {
@@ -311,7 +311,7 @@ export const habitPresets: HabitPreset[] = [
     iconId: 'apple',
     colorId: 'orange',
     period: 'daily',
-    frequency: 1,
+    frequency: 2,
     category: 'lifestyle',
   },
   {
@@ -320,7 +320,7 @@ export const habitPresets: HabitPreset[] = [
     iconId: 'book-open',
     colorId: 'purple',
     period: 'daily',
-    frequency: 1,
+    frequency: 2,
     category: 'learning',
   },
   {
@@ -347,7 +347,7 @@ export const habitPresets: HabitPreset[] = [
     iconId: 'brain',
     colorId: 'teal',
     period: 'weekly',
-    frequency: 1,
+    frequency: 3,
     category: 'learning',
   },
 ]


### PR DESCRIPTION
## 概要

習慣プリセートの推奨frequency値を更新し、より現実的なデフォルト値を提供します。健康ガイドラインや一般的な使用パターンに基づいて、6個のプリセートの目標回数を変更しました。

## 変更内容

| 習慣 | 変更前 | 変更後 | 根拠 |
|------|--------|--------|------|
| 水を飲む | 1 | **8** | 標準的な健康ガイドライン（1日8杯 約2L） |
| ポモドーロタイマーを使う | 1 | **4** | 標準的な2時間作業セッション（25分×4） |
| 写真を撮る | 1 | **3** | 適度な撮影頻度（負担にならない範囲） |
| 料理をする | 1 | **2** | 一般的な食事回数（昼食・夕食） |
| 10分間読む | 1 | **2** | 朝・夜の読書セッション |
| 新しいスキルを学ぶ | 1 | **3** | 週3回の学習ペース（period: weekly） |

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

**詳細:**
- 新規作成する習慣のみに影響（既存習慣データは影響なし）
- ユーザーはフォーム上で自由に調整可能（1-99の範囲）
- 変更ファイル: `src/constants/habit-data.ts` **のみ**

## 関連Issue

該当なし

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [x] Prisma 変更時: スキーマ検証とマイグレーション確認（該当なし）
- [x] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)（該当なし）

## テスト計画

- [ ] `/dashboard` → 「習慣を追加」ボタンをクリック
- [ ] 各プリセートを選択してfrequencyを確認:
  - 「水を飲む」→ 8
  - 「ポモドーロタイマーを使う」→ 4
  - 「写真を撮る」→ 3
  - 「料理をする」→ 2
  - 「10分間読む」→ 2
  - 「新しいスキルを学ぶ」→ 3
- [ ] +/- ボタンで調整可能であることを確認
- [ ] 習慣作成後、進捗表示が正しく動作するか確認（例: 「1 / 8」）

## 設計方針

- **保守的アプローチ**: 全18プリセート中6個のみ変更（33%）
- **維持**: 時間ベース・累計目標・単発イベント系は frequency: 1 を維持
- **ユーザー体験向上**: 適切なデフォルト値により、初回設定の手間を削減しつつ、完全な調整の自由度を保持

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->