### PR TITLE
fix: mise run ci の markdownlint MD040 を解消

### DIFF
--- a/.claude/skills/db-debug/SKILL.md
+++ b/.claude/skills/db-debug/SKILL.md
@@ -45,7 +45,7 @@ DB エラーの場合、`code`, `severity`, `constraint_name`, `table_name`, `ca
 
 ## 3層レジリエンス
 
-```
+```text
 1. withDbRetry     → DB エラー時に resetDb() + リトライ (最大2回)
 2. Stale cache     → リトライ失敗時にキャッシュ済みデータで応答
 3. logSpanOptional → タイムアウト時に null を返し、非必須データをスキップ

--- a/.claude/skills/db-debug/references/architecture.md
+++ b/.claude/skills/db-debug/references/architecture.md
@@ -6,7 +6,7 @@
 
 **ファイル:** `src/lib/db.ts`
 
-```
+```text
 getCloudflareContext() → env.DB (D1Database) → drizzle(d1Database, { schema })
 ```
 
@@ -32,7 +32,7 @@ getCloudflareContext() → env.DB (D1Database) → drizzle(d1Database, { schema 
 
 **ファイル:** `src/lib/db-retry.ts`
 
-```
+```text
 withDbRetry(name, fn, { maxRetries=1, retryOn=isDatabaseError, timeoutMs })
   ├─ 成功 → 結果を返す
   ├─ isDatabaseError → resetDb() + リトライ (最大2回)
@@ -46,7 +46,7 @@ withDbRetry(name, fn, { maxRetries=1, retryOn=isDatabaseError, timeoutMs })
 
 **ファイル:** `src/app/actions/habits/checkin.ts`, `remove-checkin.ts`
 
-```
+```text
 runWithRetry(spanName, fn, { dbTimeoutMs })
   ├─ logSpan(name, fn, { timeoutMs: dbTimeoutMs })
   ├─ TimeoutError → resetDb() + 1回リトライ
@@ -59,7 +59,7 @@ runWithRetry(spanName, fn, { dbTimeoutMs })
 
 **ファイル:** `src/lib/user.ts`
 
-```
+```text
 fetchExistingUserWithRetry(clerkId, dbTimeoutMs)
   ├─ getUserByClerkId()
   ├─ getRetryableDbReason(error) でリトライ判定
@@ -72,7 +72,7 @@ fetchExistingUserWithRetry(clerkId, dbTimeoutMs)
 
 **ファイル:** `src/constants/request-timeout.ts`
 
-```
+```text
 requestTimeoutMs (8000ms / Cloudflare: 15000ms)
   └─ dbTimeoutMs = max(3000, min(8000, requestTimeoutMs - 2000))
        └─ 個別クエリ span の timeoutMs

--- a/.claude/skills/db-debug/references/log-patterns.md
+++ b/.claude/skills/db-debug/references/log-patterns.md
@@ -4,13 +4,13 @@
 
 `logSpan` / `logInfo` / `logError` の出力形式:
 
-```
+```text
 <name>:<suffix> {"key":"value","ms":123}
 ```
 
 例:
 
-```
+```text
 query.createCheckinWithLimit:start {"habitId":"abc"}
 query.createCheckinWithLimit:end {"habitId":"abc","ms":45}
 query.createCheckinWithLimit:error {"habitId":"abc","ms":45,"error":{"name":"PostgresError","message":"duplicate key...","code":"23505"}}
@@ -47,14 +47,14 @@ query.createCheckinWithLimit:error {"habitId":"abc","ms":45,"error":{"name":"Pos
 
 ### 正常系
 
-```
+```text
 dashboard.habits:start {}
 dashboard.habits:end {"ms":120}
 ```
 
 ### タイムアウト
 
-```
+```text
 dashboard.habits:start {}
 dashboard.habits:timeout {"ms":8000}
 dashboard.habits:late-error {"error":{"name":"Error","message":"connection terminated"}}
@@ -64,7 +64,7 @@ dashboard.habits:late-error {"error":{"name":"Error","message":"connection termi
 
 ### リトライ成功
 
-```
+```text
 dashboard.habits:start {}
 dashboard.habits:retry {"attempt":1,"maxRetries":1,"error":{"name":"Error","message":"ECONNRESET"}}
 dashboard.habits:end {"ms":350}
@@ -72,7 +72,7 @@ dashboard.habits:end {"ms":350}
 
 ### リトライ失敗
 
-```
+```text
 dashboard.habits:start {}
 dashboard.habits:retry {"attempt":1,"maxRetries":1,"error":{"name":"Error","message":"ECONNRESET"}}
 dashboard.habits:final-failure {"attempt":2,"maxRetries":1,"error":{"name":"Error","message":"ECONNRESET"}}
@@ -80,13 +80,13 @@ dashboard.habits:final-failure {"attempt":2,"maxRetries":1,"error":{"name":"Erro
 
 ### 制約違反（リトライなし）
 
-```
+```text
 query.createCheckinWithLimit:error {"habitId":"abc","ms":45,"error":{"name":"PostgresError","message":"duplicate key...","code":"23505","constraint_name":"Checkin_habitId_date_unique","table_name":"Checkin"}}
 ```
 
 ### 遅いクエリ
 
-```
+```text
 query.getHabitsWithProgress:slow {"ms":150}
 ```
 

--- a/scripts/manual-debug-steps.md
+++ b/scripts/manual-debug-steps.md
@@ -10,7 +10,7 @@ Chrome が http://localhost:3000/dashboard で起動している状態
 2. **Console** タブを選択
 3. 以下のエラーがないか確認:
 
-```
+```text
 ❌ 確認すべきエラー:
 - Uncaught TypeError
 - Clerk: Refreshing the session token resulted in an infinite redirect loop
@@ -25,7 +25,7 @@ Chrome が http://localhost:3000/dashboard で起動している状態
 2. **F5** でページをリロード
 3. 以下を確認:
 
-```
+```text
 ❌ 確認すべき問題:
 - /dashboard への複数回のリクエスト (無限ループ)
 - Status: 500, 503, timeout のリクエスト


### PR DESCRIPTION
## 概要

`mise run ci` で失敗していた Markdown lint (`MD040: fenced-code-language`) を解消しました。  
未指定だったコードフェンスに `text` を付与し、CI チェックを安定化しています。

## 種別

- [x] 🐛 fix (バグ修正)
- [ ] 🚀 feature (新機能)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API / Server Actions
- [ ] データベース (Prisma)
- [ ] 認証 (Clerk)
- [ ] PWA
- [x] CI/CD
- [x] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run check` 相当以上: `mise run ci`)
- [x] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [ ] Prisma 変更時: スキーマ検証とマイグレーション確認
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
