### PR TITLE
feat: 習慣追加フロー統一（Next.js Intercepting Routes活用）

### DIFF
--- a/.storybook/mocks/clerk.tsx
+++ b/.storybook/mocks/clerk.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react'
 
 interface ClerkUser {
-  id: string
   emailAddresses: Array<{ emailAddress: string }>
+  id: string
 }
 
 export function ClerkProvider({ children }: { children: ReactNode }) {

--- a/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
+++ b/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
@@ -1,12 +1,18 @@
 import { redirect } from 'next/navigation'
 import { HabitFormServer } from '@/components/habits/HabitFormServer'
+import { HabitPresetSelectorWrapper } from '@/components/habits/HabitPresetSelectorWrapper'
 import { RouteModal } from '@/components/modals/RouteModal'
 import { SIGN_IN_PATH } from '@/constants/auth'
+import { habitPresets } from '@/constants/habit-data'
 import { createRequestMeta, logInfo, logSpanOptional } from '@/lib/logging'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
 
-export default async function NewHabitModalPage() {
+export default async function NewHabitModalPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ step?: string; preset?: string }>
+}) {
   const timeoutMs = getRequestTimeoutMs()
   const requestMeta = createRequestMeta('/habits/new')
 
@@ -21,11 +27,22 @@ export default async function NewHabitModalPage() {
     redirect(SIGN_IN_PATH)
   }
 
+  const params = await searchParams
+  const step = params.step || 'form'
+  const presetId = params.preset
+  const presetData = presetId ? habitPresets.find((p) => p.id === presetId) : undefined
+
   logInfo('request.habits.new.modal:end', requestMeta)
 
+  const title = step === 'preset' ? '習慣を追加' : '新しい習慣を追加'
+
   return (
-    <RouteModal title="新しい習慣を追加">
-      <HabitFormServer onSuccess="close" />
+    <RouteModal title={title}>
+      {step === 'preset' ? (
+        <HabitPresetSelectorWrapper />
+      ) : (
+        <HabitFormServer hideHeader={true} initialData={presetData} onSuccess="close" />
+      )}
     </RouteModal>
   )
 }

--- a/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
+++ b/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
@@ -8,12 +8,10 @@ import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
 
 // Dynamic imports for modal content - only load what's needed for the current step
-const HabitPresetSelectorWrapper = dynamic(
-  () =>
-    import('@/components/habits/HabitPresetSelectorWrapper').then((mod) => ({
-      default: mod.HabitPresetSelectorWrapper,
-    })),
-  { ssr: false }
+const HabitPresetSelectorWrapper = dynamic(() =>
+  import('@/components/habits/HabitPresetSelectorWrapper').then((mod) => ({
+    default: mod.HabitPresetSelectorWrapper,
+  }))
 )
 
 const HabitFormServer = dynamic(() =>

--- a/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
+++ b/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
@@ -44,10 +44,8 @@ export default async function NewHabitModalPage({
 
   logInfo('request.habits.new.modal:end', requestMeta)
 
-  const title = step === 'preset' ? '習慣を追加' : '新しい習慣を追加'
-
   return (
-    <RouteModal title={title}>
+    <RouteModal compact={step === 'preset'} title={step === 'preset' ? undefined : '新しい習慣を追加'}>
       {step === 'preset' ? (
         <HabitPresetSelectorWrapper />
       ) : (

--- a/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
+++ b/src/app/(dashboard)/@modal/(.)habits/new/page.tsx
@@ -1,12 +1,24 @@
+import dynamic from 'next/dynamic'
 import { redirect } from 'next/navigation'
-import { HabitFormServer } from '@/components/habits/HabitFormServer'
-import { HabitPresetSelectorWrapper } from '@/components/habits/HabitPresetSelectorWrapper'
 import { RouteModal } from '@/components/modals/RouteModal'
 import { SIGN_IN_PATH } from '@/constants/auth'
 import { habitPresets } from '@/constants/habit-data'
 import { createRequestMeta, logInfo, logSpanOptional } from '@/lib/logging'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
+
+// Dynamic imports for modal content - only load what's needed for the current step
+const HabitPresetSelectorWrapper = dynamic(
+  () =>
+    import('@/components/habits/HabitPresetSelectorWrapper').then((mod) => ({
+      default: mod.HabitPresetSelectorWrapper,
+    })),
+  { ssr: false }
+)
+
+const HabitFormServer = dynamic(() =>
+  import('@/components/habits/HabitFormServer').then((mod) => ({ default: mod.HabitFormServer }))
+)
 
 export default async function NewHabitModalPage({
   searchParams,

--- a/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
+++ b/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
@@ -1,22 +1,13 @@
 'use client'
 
-import { createId } from '@paralleldrive/cuid2'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState, useTransition } from 'react'
 import { addCheckinAction } from '@/app/actions/habits/checkin'
-import { createHabit } from '@/app/actions/habits/create'
 import { removeCheckinAction } from '@/app/actions/habits/remove-checkin'
-import type { IconName } from '@/components/basics/Icon'
 import { DesktopDashboard } from '@/components/streak/DesktopDashboard'
 import { StreakDashboard } from '@/components/streak/StreakDashboard'
 import { MAX_CONCURRENT_CHECKINS } from '@/constants/dashboard'
-import {
-  COMPLETION_THRESHOLD,
-  DEFAULT_HABIT_COLOR,
-  DEFAULT_HABIT_FREQUENCY,
-  DEFAULT_HABIT_PERIOD,
-  type Period,
-} from '@/constants/habit'
+import { COMPLETION_THRESHOLD } from '@/constants/habit'
 import { useSyncContext } from '@/contexts/SyncContext'
 import { useBeforeUnload } from '@/hooks/useBeforeUnload'
 import { getClientCookie, setClientCookie } from '@/lib/utils/cookies'
@@ -27,14 +18,14 @@ import type { User } from '@/types/user'
 
 interface DashboardWrapperProps {
   habits: HabitWithProgress[]
+  initialView?: 'dashboard' | 'simple'
   todayLabel: string
   user: User
-  initialView?: 'dashboard' | 'simple'
 }
 
 interface CheckinTask {
-  habitId: string
   dateKey: string
+  habitId: string
   isRemove?: boolean
   rollback?: () => void
 }
@@ -362,58 +353,6 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
     }
   }, [])
 
-  const handleAddHabit = async (
-    name: string,
-    icon: IconName,
-    options?: { color?: string | null; period?: Period; frequency?: number }
-  ) => {
-    const nextPeriod = options?.period ?? DEFAULT_HABIT_PERIOD
-    const nextColor = options?.color ?? DEFAULT_HABIT_COLOR
-    const nextFrequency = options?.frequency ?? DEFAULT_HABIT_FREQUENCY
-    const optimisticId = `optimistic-${createId()}`
-    const now = new Date().toISOString()
-    const optimisticHabit: HabitWithProgress = {
-      id: optimisticId,
-      userId: user.id,
-      name,
-      icon,
-      color: nextColor,
-      period: nextPeriod,
-      frequency: nextFrequency,
-      archived: false,
-      archivedAt: null,
-      createdAt: now,
-      updatedAt: now,
-      currentProgress: 0,
-      streak: 0,
-      completionRate: 0,
-    }
-
-    setOptimisticHabits((current) => [optimisticHabit, ...current])
-
-    const formData = new FormData()
-    formData.append('name', name)
-    formData.append('icon', icon)
-    formData.append('color', nextColor)
-    formData.append('period', nextPeriod)
-    formData.append('frequency', String(nextFrequency))
-
-    const result = await createHabit(formData)
-
-    if (result.ok) {
-      // サーバーから返されたIDで楽観的IDを置換
-      setOptimisticHabits((current) =>
-        current.map((habit) => (habit.id === optimisticId ? { ...habit, id: result.data.id } : habit))
-      )
-      // 5分後にバックグラウンドリフレッシュ（整合性確保のためのフォールバック）
-      scheduleLazyRefresh()
-      return
-    }
-
-    setOptimisticHabits((current) => current.filter((habit) => habit.id !== optimisticId))
-    appToast.error('習慣の作成に失敗しました', result.error)
-  }
-
   const queueOptimisticCheckin = (
     habitId: string,
     options: {
@@ -477,7 +416,6 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
           habits={activeHabits}
           initialView={initialView}
           onAddCheckin={handleAddCheckin}
-          onAddHabit={handleAddHabit}
           onArchiveOptimistic={archiveOptimistically}
           onDeleteOptimistic={deleteOptimistically}
           onRemoveCheckin={handleRemoveCheckin}
@@ -491,7 +429,6 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
         <DesktopDashboard
           habits={activeHabits}
           onAddCheckin={handleAddCheckin}
-          onAddHabit={handleAddHabit}
           onArchiveOptimistic={archiveOptimistically}
           onDeleteOptimistic={deleteOptimistically}
           onRemoveCheckin={handleRemoveCheckin}

--- a/src/app/(dashboard)/habits/new/page.tsx
+++ b/src/app/(dashboard)/habits/new/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { HabitFormServer } from '@/components/habits/HabitFormServer'
+import { HabitPresetSelectorWrapper } from '@/components/habits/HabitPresetSelectorWrapper'
 import { SIGN_IN_PATH } from '@/constants/auth'
+import { habitPresets } from '@/constants/habit-data'
 import { createRequestMeta, logInfo, logSpanOptional } from '@/lib/logging'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
@@ -11,7 +13,11 @@ export const metadata: Metadata = {
   description: '新しい習慣を作成する',
 }
 
-export default async function NewHabitPage() {
+export default async function NewHabitPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ step?: string; preset?: string }>
+}) {
   const timeoutMs = getRequestTimeoutMs()
   const requestMeta = createRequestMeta('/habits/new')
 
@@ -24,7 +30,22 @@ export default async function NewHabitPage() {
     redirect(SIGN_IN_PATH)
   }
 
+  const params = await searchParams
+  const step = params.step || 'form'
+  const presetId = params.preset
+
+  // プリセットIDから初期値を取得
+  const presetData = presetId ? habitPresets.find((p) => p.id === presetId) : undefined
+
   logInfo('request.habits.new:end', requestMeta)
+
+  if (step === 'preset') {
+    return (
+      <div className="flex flex-1 flex-col gap-6 p-4">
+        <HabitPresetSelectorWrapper />
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-1 flex-col gap-6 p-4">
@@ -34,7 +55,7 @@ export default async function NewHabitPage() {
       </div>
 
       <div className="mx-auto w-full max-w-md">
-        <HabitFormServer />
+        <HabitFormServer initialData={presetData} />
       </div>
     </div>
   )

--- a/src/app/(dashboard)/habits/page.tsx
+++ b/src/app/(dashboard)/habits/page.tsx
@@ -51,7 +51,7 @@ export default async function HabitsPage() {
           <p className="text-muted-foreground">あなたの習慣を管理しましょう</p>
         </div>
         <Button asChild size="lg" variant="default">
-          <Link href="/habits/new">
+          <Link href="/habits/new?step=preset">
             <Icon className="mr-2" name="plus" size={20} />
             新しい習慣
           </Link>

--- a/src/app/actions/habits/checkin-shared.ts
+++ b/src/app/actions/habits/checkin-shared.ts
@@ -6,28 +6,28 @@ import { getHabitById } from '@/lib/queries/habit'
 export type SpanRunner = <T>(name: string, fn: () => Promise<T>, data?: Record<string, unknown>) => Promise<T>
 
 export interface HabitCheckinSpans {
-  timeoutMs: number
   dbTimeoutMs: number
   runWithDbTimeout: SpanRunner
-  runWithRetry: SpanRunner
   runWithRequestTimeout: SpanRunner
+  runWithRetry: SpanRunner
+  timeoutMs: number
 }
 
 export interface HabitCheckinParams {
-  habitId: string
-  dateKey?: string
   baseMeta: Record<string, unknown>
+  dateKey?: string
+  habitId: string
   spans: HabitCheckinSpans
 }
 
 export type HabitRecord = NonNullable<Awaited<ReturnType<typeof getHabitById>>>
 
 interface RequireHabitForUserParams {
+  actionName: string
   habitId: string
-  userId: string
   meta: Record<string, unknown>
   runWithRetry: SpanRunner
-  actionName: string
+  userId: string
 }
 
 export function createHabitCheckinSpans(timeoutMs: number): HabitCheckinSpans {

--- a/src/app/actions/habits/checkin.ts
+++ b/src/app/actions/habits/checkin.ts
@@ -108,7 +108,7 @@ export async function addCheckinAction(habitId: string, dateKey?: string): Habit
           )
         },
         catch: (error) => error,
-      })()
+      })
     }),
     Result.mapError((error) => serializeActionError(error, 'チェックインの切り替えに失敗しました'))
   )

--- a/src/app/actions/habits/create.ts
+++ b/src/app/actions/habits/create.ts
@@ -42,7 +42,7 @@ export async function createHabit(formData: FormData): ServerActionResultAsync<{
       return await Result.try({
         try: async () => await createHabitQuery(validInput),
         catch: (error) => new DatabaseError({ cause: error }),
-      })()
+      })
     })
   )
 

--- a/src/app/actions/habits/remove-checkin.ts
+++ b/src/app/actions/habits/remove-checkin.ts
@@ -129,7 +129,7 @@ export async function removeCheckinAction(
           )
         },
         catch: (error) => error,
-      })()
+      })
     }),
     Result.mapError((error) => serializeActionError(error, 'チェックインの削除に失敗しました'))
   )

--- a/src/app/actions/habits/remove-checkin.ts
+++ b/src/app/actions/habits/remove-checkin.ts
@@ -46,8 +46,8 @@ async function resolveWeekStartDay(
 }
 
 interface RemoveCheckinResultData {
-  deleted: boolean
   currentCount: number
+  deleted: boolean
 }
 
 async function performRemoveCheckin(params: HabitCheckinParams): Promise<RemoveCheckinResultData> {

--- a/src/app/actions/habits/reset.ts
+++ b/src/app/actions/habits/reset.ts
@@ -47,7 +47,7 @@ export async function resetHabitProgressAction(habitId: string, dateKey?: string
           return
         },
         catch: (error) => error,
-      })()
+      })
     }),
     Result.mapError((error) => serializeActionError(error, '進捗のリセットに失敗しました'))
   )

--- a/src/app/debug/repro-concurrency/actions.ts
+++ b/src/app/debug/repro-concurrency/actions.ts
@@ -13,10 +13,6 @@ export interface ConcurrencyParams {
 }
 
 export interface ConcurrencyResult {
-  concurrency: number
-  iterations: number
-  startedAt: string
-  finishedAt: string
   batches: Array<{
     index: number
     ok: number
@@ -26,18 +22,22 @@ export interface ConcurrencyResult {
     avgMs: number
     errors: string[]
   }>
+  concurrency: number
+  finishedAt: string
+  iterations: number
+  startedAt: string
 }
 
 interface TaskResult {
-  ok: boolean
   durationMs: number
   errors: string[]
+  ok: boolean
 }
 
 interface TimedCheck {
-  ok: boolean
   durationMs: number
   error?: string
+  ok: boolean
 }
 
 function clampNumber(value: number, min: number, max: number, fallback: number): number {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,7 +85,6 @@
 }
 
 :root {
-  color-scheme: light;
   --radius: 0.625rem;
 
   /* shadcn/ui 互換マッピング */
@@ -120,13 +119,14 @@
   --sidebar-accent-foreground: var(--slate-11);
   --sidebar-border: var(--slate-6);
   --sidebar-ring: var(--ring);
+  color-scheme: light;
 }
 
 .dark {
-  color-scheme: dark;
   --primary-foreground: var(--teal-12);
   --destructive-foreground: var(--red-12);
   --success-foreground: var(--teal-12);
+  color-scheme: dark;
 }
 
 /* テーマバリエーション（data-theme属性で切替）- Radix Colors */

--- a/src/app/health/page.tsx
+++ b/src/app/health/page.tsx
@@ -14,21 +14,21 @@ type Status = 'ok' | 'warn' | 'error'
 type DbBinding = 'd1' | 'missing'
 
 interface HealthCheck {
+  description: string
   id: string
   label: string
-  status: Status
-  description: string
   meta?: string
+  status: Status
 }
 
 interface EnvSnapshot {
-  runtime: 'workers' | 'node'
-  nextjsEnv?: string
   clerkPublishableKey?: string
   clerkSecretKey?: string
+  d1Binding: boolean
+  nextjsEnv?: string
+  runtime: 'workers' | 'node'
   signInUrl?: string
   signUpUrl?: string
-  d1Binding: boolean
 }
 
 const STATUS_BADGE_STYLES: Record<Status, string> = {

--- a/src/components/SyncIndicator.tsx
+++ b/src/components/SyncIndicator.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CheckCircle2, CloudUpload } from 'lucide-react'
+import { CloudUpload } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { SYNC_INDICATOR_DELAY_MS, SYNC_INDICATOR_MIN_DISPLAY_MS } from '@/constants/sync'
 import { useSyncContext } from '@/contexts/SyncContext'
@@ -59,19 +59,8 @@ export function SyncIndicator() {
   }, [isSyncing])
 
   return (
-    <div
-      aria-atomic="true"
-      aria-label={showSyncIcon ? '同期中' : '最新'}
-      aria-live="polite"
-      className="flex min-h-[44px] min-w-[44px] items-center justify-center"
-      role="status"
-      title={showSyncIcon ? '同期中' : '最新'}
-    >
-      {showSyncIcon ? (
-        <CloudUpload className="h-6 w-6 text-secondary-foreground" />
-      ) : (
-        <CheckCircle2 className="h-6 w-6 text-secondary-foreground" />
-      )}
+    <div aria-atomic="true" aria-label={showSyncIcon ? '同期中' : '最新'} aria-live="polite" role="status">
+      {showSyncIcon && <CloudUpload className="h-6 w-6 text-secondary-foreground" />}
     </div>
   )
 }

--- a/src/components/SyncIndicator.tsx
+++ b/src/components/SyncIndicator.tsx
@@ -59,7 +59,13 @@ export function SyncIndicator() {
   }, [isSyncing])
 
   return (
-    <div aria-atomic="true" aria-label={showSyncIcon ? '同期中' : '最新'} aria-live="polite" role="status">
+    <div
+      aria-atomic="true"
+      aria-label={showSyncIcon ? '同期中' : '最新'}
+      aria-live="polite"
+      className="flex h-6 w-6 shrink-0 items-center justify-center"
+      role="status"
+    >
       {showSyncIcon && <CloudUpload className="h-6 w-6 text-secondary-foreground" />}
     </div>
   )

--- a/src/components/basics/Input.tsx
+++ b/src/components/basics/Input.tsx
@@ -3,8 +3,8 @@ import { Input as BaseInput } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
 export interface InputProps extends React.ComponentProps<'input'> {
-  error?: boolean
   disablePasswordManagers?: boolean
+  error?: boolean
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(

--- a/src/components/basics/ThemeToggle.tsx
+++ b/src/components/basics/ThemeToggle.tsx
@@ -15,8 +15,8 @@ import { DEFAULT_THEME_MODE } from '@/constants/theme'
 import { cn } from '@/lib/utils'
 
 interface ThemeToggleProps {
-  buttonVariant?: ButtonProps['variant']
   buttonClassName?: string
+  buttonVariant?: ButtonProps['variant']
 }
 
 export function ThemeToggle({ buttonVariant = 'secondary', buttonClassName }: ThemeToggleProps) {

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -6,10 +6,10 @@ import { cn } from '@/lib/utils'
 import { DashboardStatsCard } from './DashboardStatsCard'
 
 interface DashboardHeaderProps {
+  onAddClick?: () => void
   todayActive: number
   totalDaily: number
   totalStreak: number
-  onAddClick?: () => void
   variant: 'mobile' | 'desktop'
 }
 

--- a/src/components/dashboard/DashboardStatsCard.tsx
+++ b/src/components/dashboard/DashboardStatsCard.tsx
@@ -5,11 +5,11 @@ import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
 export interface DashboardStatsCardProps {
+  className?: string
+  suffix?: string
+  total?: number
   type: 'progress' | 'streak'
   value: number | string
-  total?: number
-  suffix?: string
-  className?: string
 }
 
 export function DashboardStatsCard({ type, value, total, suffix, className }: DashboardStatsCardProps) {

--- a/src/components/dashboard/HabitActionDrawer.tsx
+++ b/src/components/dashboard/HabitActionDrawer.tsx
@@ -11,12 +11,12 @@ import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } f
 import type { HabitWithProgress } from '@/types/habit'
 
 interface HabitActionDrawerProps {
-  open: boolean
   habit: HabitWithProgress | null
-  onOpenChange: (open: boolean) => void
   onArchiveOptimistic?: OptimisticHandler
   onDeleteOptimistic?: OptimisticHandler
+  onOpenChange: (open: boolean) => void
   onResetOptimistic?: OptimisticHandler
+  open: boolean
 }
 
 export function HabitActionDrawer({

--- a/src/components/habits/HabitActionDialog.tsx
+++ b/src/components/habits/HabitActionDialog.tsx
@@ -21,20 +21,20 @@ import { formatSerializableError, type SerializableHabitError } from '@/lib/erro
 import type { OptimisticHandler } from './types'
 
 interface HabitActionDialogProps {
-  habitId: string
-  trigger?: ReactNode | null
-  onOptimistic?: OptimisticHandler
-  title: string
-  description: ReactNode
-  confirmLabel: string
-  confirmClassName?: string
-  successMessage: string
-  errorMessage: string
   action: (habitId: string) => ServerActionResultAsync<unknown, SerializableHabitError>
-  retryOnError?: boolean
-  open?: boolean
+  confirmClassName?: string
+  confirmLabel: string
   defaultOpen?: boolean
+  description: ReactNode
+  errorMessage: string
+  habitId: string
   onOpenChange?: (open: boolean) => void
+  onOptimistic?: OptimisticHandler
+  open?: boolean
+  retryOnError?: boolean
+  successMessage: string
+  title: string
+  trigger?: ReactNode | null
 }
 
 const waitForRetry = (delayMs: number) =>

--- a/src/components/habits/HabitCircle.tsx
+++ b/src/components/habits/HabitCircle.tsx
@@ -7,18 +7,18 @@ import { COMPLETION_ACTION_LABEL, DEFAULT_HABIT_ICON } from '@/constants/habit'
 import { cn } from '@/lib/utils'
 
 export interface HabitCircleProps {
+  /** カスタムクラス名 */
+  className?: string
+  /** 完了状態 */
+  completed: boolean
   /** 習慣名 */
   habitName: string
   /** アイコン */
   icon?: IconName | null
-  /** 完了状態 */
-  completed: boolean
   /** クリックハンドラー */
   onClick?: () => void
   /** サイズバリアント */
   size?: 'sm' | 'md' | 'lg'
-  /** カスタムクラス名 */
-  className?: string
 }
 
 const sizeMap = {

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -73,6 +73,7 @@ export function HabitFormServer({
   const watchedName = form.watch('name')
 
   const selectedColorValue = getColorById(watchedColor || DEFAULT_HABIT_COLOR).color
+  const selectedColorForeground = getColorById(watchedColor || DEFAULT_HABIT_COLOR).foreground
   const SelectedIconComponent = getIconById(watchedIcon || DEFAULT_HABIT_ICON).icon
   const currentPeriod = getPeriodById(watchedPeriod || DEFAULT_HABIT_PERIOD)
 
@@ -291,7 +292,7 @@ export function HabitFormServer({
           render={({ field }) => (
             <div className="space-y-3">
               <div className="font-medium text-muted-foreground text-sm uppercase tracking-wide">カラー</div>
-              <div className="scrollbar-hide flex justify-center gap-3 overflow-x-auto pt-1 pb-2">
+              <div className="scrollbar-hide flex gap-3 overflow-x-auto px-1 pt-1 pb-2">
                 {habitColors.map((color) => {
                   const isSelected = field.value === color.id
                   return (
@@ -437,6 +438,7 @@ export function HabitFormServer({
               onClick={form.handleSubmit(handleSubmit)}
               style={{
                 backgroundColor: watchedName?.trim() && !isSaving ? selectedColorValue : undefined,
+                color: watchedName?.trim() && !isSaving ? selectedColorForeground : undefined,
               }}
               type="button"
             >

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -11,7 +11,15 @@ import { createHabit } from '@/app/actions/habits/create'
 import { updateHabitAction } from '@/app/actions/habits/update'
 import { Button } from '@/components/basics/Button'
 import { DEFAULT_HABIT_COLOR, DEFAULT_HABIT_ICON, DEFAULT_HABIT_PERIOD } from '@/constants/habit'
-import { getColorById, getIconById, getPeriodById, habitColors, habitIcons, taskPeriods } from '@/constants/habit-data'
+import {
+  getColorById,
+  getIconById,
+  getPeriodById,
+  type HabitPreset,
+  habitColors,
+  habitIcons,
+  taskPeriods,
+} from '@/constants/habit-data'
 import { formatSerializableError } from '@/lib/errors/serializable'
 import { cn } from '@/lib/utils'
 import { HabitInputSchema } from '@/schemas/habit'
@@ -19,11 +27,11 @@ import { buildHabitFormData, getHabitFormDefaults, type HabitFormValues } from '
 import type { Habit, HabitWithProgress } from '@/types/habit'
 
 interface HabitFormServerProps {
-  initialData?: Habit | HabitWithProgress
+  hideHeader?: boolean
+  initialData?: Habit | HabitWithProgress | HabitPreset
   onSubmit?: (data: FormValues) => Promise<void> | void
   onSuccess?: 'close' | 'redirect'
   submitLabel?: string
-  hideHeader?: boolean
 }
 
 type FormValues = HabitFormValues

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -3,7 +3,7 @@
 import { valibotResolver } from '@hookform/resolvers/valibot'
 import { Check, ChevronLeft, Clock } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { Resolver } from 'react-hook-form'
 import { Controller, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -47,8 +47,11 @@ export function HabitFormServer({
   const [isSaving, setIsSaving] = useState(false)
   const [isInitialLoad, setIsInitialLoad] = useState(true)
 
-  // 初期値を設定
-  const defaultValues: HabitFormValues = getHabitFormDefaults(initialData)
+  // 初期値を設定（メモ化して不要な再計算を防ぐ）
+  const defaultValues: HabitFormValues = useMemo(() => getHabitFormDefaults(initialData), [initialData])
+
+  // 編集モードかどうかを判定（HabitPresetの場合は新規作成扱い）
+  const isEdit = useMemo(() => initialData && !('category' in initialData), [initialData])
 
   const form = useForm<FormValues>({
     resolver: valibotResolver(HabitInputSchema) as Resolver<FormValues>,
@@ -89,13 +92,16 @@ export function HabitFormServer({
     setIsSaving(true)
 
     const formData = buildHabitFormData(data)
-    const result = initialData ? await updateHabitAction(initialData.id, formData) : await createHabit(formData)
+    // HabitPresetの場合は新規作成、既存のHabitの場合は更新
+    const result = isEdit
+      ? await updateHabitAction((initialData as Habit | HabitWithProgress).id, formData)
+      : await createHabit(formData)
 
     setIsSaving(false)
 
     if (result.ok) {
-      toast.success(initialData ? '習慣を更新しました' : '習慣を作成しました', {
-        description: initialData ? `「${data.name}」を更新しました` : `「${data.name}」が追加されました`,
+      toast.success(isEdit ? '習慣を更新しました' : '習慣を作成しました', {
+        description: isEdit ? `「${data.name}」を更新しました` : `「${data.name}」が追加されました`,
       })
       form.reset()
 
@@ -105,7 +111,7 @@ export function HabitFormServer({
         router.push('/dashboard')
       }
     } else {
-      toast.error(initialData ? '習慣の更新に失敗しました' : '習慣の作成に失敗しました', {
+      toast.error(isEdit ? '習慣の更新に失敗しました' : '習慣の作成に失敗しました', {
         description: formatSerializableError(result.error),
       })
     }

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -51,7 +51,7 @@ export function HabitFormServer({
   const defaultValues: HabitFormValues = useMemo(() => getHabitFormDefaults(initialData), [initialData])
 
   // 編集モードかどうかを判定（HabitPresetの場合は新規作成扱い）
-  const isEdit = useMemo(() => initialData && !('category' in initialData), [initialData])
+  const isEdit = useMemo(() => Boolean(initialData && !('category' in initialData)), [initialData])
 
   const form = useForm<FormValues>({
     resolver: valibotResolver(HabitInputSchema) as Resolver<FormValues>,
@@ -141,7 +141,7 @@ export function HabitFormServer({
             <ChevronLeft className="h-5 w-5" />
             <span className="text-sm">戻る</span>
           </Button>
-          <h1 className="font-semibold text-foreground text-lg">{initialData ? '習慣を編集' : '新しい習慣'}</h1>
+          <h1 className="font-semibold text-foreground text-lg">{isEdit ? '習慣を編集' : '新しい習慣'}</h1>
           <Button
             className={cn(
               'h-auto p-0 hover:bg-transparent',

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -431,7 +431,7 @@ export function HabitFormServer({
 
         {/* Submit Button for Modal */}
         {hideHeader && (
-          <div className="mt-8">
+          <div className="sticky bottom-0 mt-8 bg-background pt-2 pb-4">
             <Button
               className="w-full"
               disabled={!watchedName?.trim() || isSaving}

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -76,6 +76,7 @@ export function HabitFormServer({
   const selectedColorForeground = getColorById(watchedColor || DEFAULT_HABIT_COLOR).foreground
   const SelectedIconComponent = getIconById(watchedIcon || DEFAULT_HABIT_ICON).icon
   const currentPeriod = getPeriodById(watchedPeriod || DEFAULT_HABIT_PERIOD)
+  const submitContent = isSaving ? <Check className="h-5 w-5" /> : submitLabel
 
   async function handleExternalSubmit(data: FormValues) {
     if (!onSubmit) {
@@ -121,9 +122,9 @@ export function HabitFormServer({
   async function handleSubmit(data: FormValues) {
     if (onSubmit) {
       await handleExternalSubmit(data)
-    } else {
-      await handleDefaultSubmit(data)
+      return
     }
+    await handleDefaultSubmit(data)
   }
 
   return (
@@ -154,7 +155,7 @@ export function HabitFormServer({
             type="button"
             variant="ghost"
           >
-            {isSaving ? <Check className="h-5 w-5" /> : submitLabel}
+            {submitContent}
           </Button>
         </header>
       )}
@@ -442,7 +443,7 @@ export function HabitFormServer({
               }}
               type="button"
             >
-              {isSaving ? <Check className="h-5 w-5" /> : submitLabel}
+              {submitContent}
             </Button>
           </div>
         )}

--- a/src/components/habits/HabitPresetSelectorWrapper.tsx
+++ b/src/components/habits/HabitPresetSelectorWrapper.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { HabitPresetSelector } from '@/components/streak/HabitPresetSelector'
+
+export function HabitPresetSelectorWrapper() {
+  const router = useRouter()
+
+  return (
+    <HabitPresetSelector
+      onClose={() => router.back()}
+      onCreateCustom={() => {
+        router.push('/habits/new?step=form')
+      }}
+      onSelectPreset={(preset) => {
+        router.push(`/habits/new?step=form&preset=${preset.id}`)
+      }}
+    />
+  )
+}

--- a/src/components/habits/HabitPresetSelectorWrapper.tsx
+++ b/src/components/habits/HabitPresetSelectorWrapper.tsx
@@ -10,10 +10,10 @@ export function HabitPresetSelectorWrapper() {
     <HabitPresetSelector
       onClose={() => router.back()}
       onCreateCustom={() => {
-        router.push('/habits/new?step=form')
+        router.replace('/habits/new?step=form')
       }}
       onSelectPreset={(preset) => {
-        router.push(`/habits/new?step=form&preset=${preset.id}`)
+        router.replace(`/habits/new?step=form&preset=${preset.id}`)
       }}
     />
   )

--- a/src/components/habits/HabitTable.tsx
+++ b/src/components/habits/HabitTable.tsx
@@ -15,9 +15,9 @@ import type { HabitWithProgress } from '@/types/habit'
 import { HabitTableClient } from './HabitTableClient'
 
 interface HabitTableProps {
-  userId: string
   clerkId: string
   requestMeta?: { route: string; requestId: string }
+  userId: string
 }
 
 export async function HabitTable({ userId, clerkId, requestMeta }: HabitTableProps) {

--- a/src/components/habits/HabitTableActions.tsx
+++ b/src/components/habits/HabitTableActions.tsx
@@ -8,11 +8,11 @@ import { HabitArchiveDialog } from './HabitArchiveDialog'
 import { HabitDeleteDialog } from './HabitDeleteDialog'
 
 interface HabitTableActionsProps {
+  archived: boolean
   habitId: string
   habitName: string
-  archived: boolean
-  onEdit: (habitId: string) => void
   onArchiveOptimistic?: OptimisticHandler
+  onEdit: (habitId: string) => void
 }
 
 export function HabitTableActions({

--- a/src/components/habits/types.ts
+++ b/src/components/habits/types.ts
@@ -4,11 +4,11 @@ export type OptimisticRollback = () => void
 export type OptimisticHandler = () => OptimisticRollback | undefined
 
 export interface HabitDialogProps {
+  defaultOpen?: boolean
   habitId: string
   habitName: string
-  trigger?: ReactNode | null
+  onOpenChange?: (open: boolean) => void
   onOptimistic?: OptimisticHandler
   open?: boolean
-  defaultOpen?: boolean
-  onOpenChange?: (open: boolean) => void
+  trigger?: ReactNode | null
 }

--- a/src/components/modals/RouteModal.tsx
+++ b/src/components/modals/RouteModal.tsx
@@ -4,8 +4,8 @@ import { useRouter } from 'next/navigation'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 
 interface RouteModalProps {
-  title: string
   children: React.ReactNode
+  title: string
 }
 
 export function RouteModal({ title, children }: RouteModalProps) {

--- a/src/components/modals/RouteModal.tsx
+++ b/src/components/modals/RouteModal.tsx
@@ -2,13 +2,15 @@
 
 import { useRouter } from 'next/navigation'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { cn } from '@/lib/utils'
 
 interface RouteModalProps {
   children: React.ReactNode
-  title: string
+  compact?: boolean
+  title?: string
 }
 
-export function RouteModal({ title, children }: RouteModalProps) {
+export function RouteModal({ title, children, compact }: RouteModalProps) {
   const router = useRouter()
 
   const handleOpenChange = (open: boolean) => {
@@ -24,12 +26,24 @@ export function RouteModal({ title, children }: RouteModalProps) {
 
   return (
     <Sheet onOpenChange={handleOpenChange} open={true}>
-      <SheetContent className="mt-2 h-[90vh] p-6 sm:mx-auto sm:h-auto sm:max-w-xl" side="bottom">
+      <SheetContent
+        className={cn(
+          'mt-2 h-[90vh] sm:mx-auto sm:h-[85vh] sm:max-w-xl',
+          compact ? 'overflow-hidden p-0 [&>button:first-child]:hidden' : 'p-6'
+        )}
+        side="bottom"
+      >
         <div className="flex h-full flex-col overflow-hidden">
-          <SheetHeader className="flex-shrink-0 pb-2">
-            <SheetTitle>{title}</SheetTitle>
-          </SheetHeader>
-          <div className="-mx-6 flex-1 overflow-y-auto overflow-x-hidden px-6">{children}</div>
+          {compact ? (
+            <SheetTitle className="sr-only">{title ?? '習慣を追加'}</SheetTitle>
+          ) : (
+            title && (
+              <SheetHeader className="flex-shrink-0 pb-2">
+                <SheetTitle>{title}</SheetTitle>
+              </SheetHeader>
+            )
+          )}
+          <div className={cn('flex-1 overflow-y-auto overflow-x-hidden', !compact && '-mx-6 px-6')}>{children}</div>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/components/streak/DesktopDashboard.tsx
+++ b/src/components/streak/DesktopDashboard.tsx
@@ -1,14 +1,12 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import type { Period } from '@/constants/habit'
 import { useDashboardStats } from '@/hooks/use-dashboard-stats'
-import { usePresetSelection } from '@/hooks/use-preset-selection'
 import { filterHabitsByPeriod } from '@/lib/utils/habits'
 import type { User } from '@/types/user'
-import { HabitForm } from './HabitForm'
 import { HabitListView } from './HabitListView'
-import { HabitPresetSelector } from './HabitPresetSelector'
 import type { DashboardBaseProps } from './types'
 
 interface DesktopDashboardProps extends DashboardBaseProps {
@@ -16,11 +14,9 @@ interface DesktopDashboardProps extends DashboardBaseProps {
 }
 
 type PeriodFilter = 'all' | Period
-type View = 'dashboard' | 'preset-selector' | 'add'
 
 export function DesktopDashboard({
   habits,
-  onAddHabit,
   onAddCheckin,
   onRemoveCheckin,
   onArchiveOptimistic,
@@ -28,52 +24,12 @@ export function DesktopDashboard({
   onResetOptimistic,
   todayLabel,
 }: DesktopDashboardProps) {
-  const [currentView, setCurrentView] = useState<View>('dashboard')
+  const router = useRouter()
   const [periodFilter, setPeriodFilter] = useState<PeriodFilter>('all')
 
-  const { selectedPreset, selectPreset, clearPreset } = usePresetSelection()
   const { completedHabitIds, todayActive, totalDaily, totalStreak } = useDashboardStats(habits)
 
   const filteredHabits = useMemo(() => filterHabitsByPeriod(habits, periodFilter), [habits, periodFilter])
-
-  if (currentView === 'preset-selector') {
-    return (
-      <div className="space-y-6 p-6">
-        <HabitPresetSelector
-          onClose={() => {
-            clearPreset()
-            setCurrentView('dashboard')
-          }}
-          onCreateCustom={() => {
-            clearPreset()
-            setCurrentView('add')
-          }}
-          onSelectPreset={(preset) => {
-            selectPreset(preset)
-            setCurrentView('add')
-          }}
-        />
-      </div>
-    )
-  }
-
-  if (currentView === 'add') {
-    return (
-      <HabitForm
-        onBack={() => setCurrentView('preset-selector')}
-        onSubmit={async (input) => {
-          await onAddHabit(input.name, input.icon, {
-            color: input.color,
-            period: input.period,
-            frequency: input.frequency,
-          })
-          clearPreset()
-          setCurrentView('dashboard')
-        }}
-        preset={selectedPreset}
-      />
-    )
-  }
 
   return (
     <div className="space-y-6 p-6">
@@ -82,7 +38,7 @@ export function DesktopDashboard({
         filteredHabits={filteredHabits}
         habits={habits}
         onAddCheckin={onAddCheckin}
-        onAddHabit={() => setCurrentView('preset-selector')}
+        onAddHabit={() => router.push('/habits/new?step=preset')}
         onArchiveOptimistic={onArchiveOptimistic}
         onDeleteOptimistic={onDeleteOptimistic}
         onPeriodChange={setPeriodFilter}

--- a/src/components/streak/HabitCard.tsx
+++ b/src/components/streak/HabitCard.tsx
@@ -11,11 +11,11 @@ import { cn } from '@/lib/utils'
 import type { HabitWithProgress } from '@/types/habit'
 
 interface HabitCardProps {
-  habit: HabitWithProgress
   completed: boolean
-  onToggle: () => void
-  onEdit?: () => void
+  habit: HabitWithProgress
   onDelete?: () => void
+  onEdit?: () => void
+  onToggle: () => void
 }
 
 export function HabitCard({ habit, completed, onToggle, onEdit, onDelete }: HabitCardProps) {

--- a/src/components/streak/HabitEditModal.tsx
+++ b/src/components/streak/HabitEditModal.tsx
@@ -11,8 +11,8 @@ import type { HabitWithProgress } from '@/types/habit'
 interface HabitEditModalProps {
   habit: HabitWithProgress
   onClose: () => void
-  onSave: (updatedHabit: Partial<HabitWithProgress>) => void
   onDelete: (habitId: string) => void
+  onSave: (updatedHabit: Partial<HabitWithProgress>) => void
 }
 
 export function HabitEditModal({ habit, onClose, onSave, onDelete }: HabitEditModalProps) {

--- a/src/components/streak/HabitForm.tsx
+++ b/src/components/streak/HabitForm.tsx
@@ -183,7 +183,7 @@ export function HabitForm({ onBack, onSubmit, preset }: HabitFormProps) {
 
         <div className="space-y-3">
           <p className="font-medium text-muted-foreground text-sm uppercase tracking-wide">カラー</p>
-          <div className="scrollbar-hide flex gap-3 overflow-x-auto pb-2">
+          <div className="scrollbar-hide flex gap-3 overflow-x-auto px-1 pb-2">
             {habitColors.map((color) => {
               const isSelected = selectedColor === color.id
               return (

--- a/src/components/streak/HabitListCard.tsx
+++ b/src/components/streak/HabitListCard.tsx
@@ -10,13 +10,13 @@ import { cn } from '@/lib/utils'
 import type { HabitWithProgress } from '@/types/habit'
 
 interface HabitListCardProps {
-  habit: HabitWithProgress
   completed: boolean
   dimmed?: boolean
   dimmedOpacity?: number
+  habit: HabitWithProgress
   onAdd?: () => void
-  onRemove?: () => void
   onLongPressOrContextMenu: () => void
+  onRemove?: () => void
 }
 
 export function HabitListCard({

--- a/src/components/streak/HabitListView.tsx
+++ b/src/components/streak/HabitListView.tsx
@@ -93,7 +93,7 @@ export function HabitListView({
       <div className="flex-1 space-y-6 px-4 pt-4 pb-10">
         <header className="sticky top-0 z-20 rounded-2xl border border-border/60 bg-background/80 px-4 py-4 shadow-black/5 shadow-sm backdrop-blur-xl supports-[backdrop-filter]:bg-background/60">
           <div className="mb-4">
-            <p className="text-muted-foreground text-xs tracking-wide">{todayLabel}</p>
+            <p className="text-foreground/70 text-xs tracking-wide">{todayLabel}</p>
             <h1 className="font-semibold text-2xl text-foreground">今日の習慣</h1>
           </div>
 

--- a/src/components/streak/HabitListView.tsx
+++ b/src/components/streak/HabitListView.tsx
@@ -22,17 +22,17 @@ const HabitActionDrawer = dynamic(
 )
 
 interface HabitListViewProps {
-  habits: HabitWithProgress[]
-  filteredHabits: HabitWithProgress[]
   completedHabitIds: Set<string>
-  periodFilter: 'all' | Period
-  onPeriodChange: (filter: 'all' | Period) => void
+  filteredHabits: HabitWithProgress[]
+  habits: HabitWithProgress[]
   onAddCheckin?: (habitId: string) => Promise<void>
-  onRemoveCheckin?: (habitId: string) => Promise<void>
   onAddHabit: () => void
   onArchiveOptimistic?: (habitId: string) => OptimisticRollback
   onDeleteOptimistic?: (habitId: string) => OptimisticRollback
+  onPeriodChange: (filter: 'all' | Period) => void
+  onRemoveCheckin?: (habitId: string) => Promise<void>
   onResetOptimistic?: (habitId: string) => OptimisticRollback
+  periodFilter: 'all' | Period
   todayActive: number
   todayLabel: string
   totalDaily: number

--- a/src/components/streak/HabitPresetSelector.tsx
+++ b/src/components/streak/HabitPresetSelector.tsx
@@ -160,8 +160,6 @@ export function HabitPresetSelector({ onClose, onSelectPreset, onCreateCustom }:
           </div>
         )}
       </div>
-
-      <div className="h-8" />
     </div>
   )
 }

--- a/src/components/streak/HabitPresetSelector.tsx
+++ b/src/components/streak/HabitPresetSelector.tsx
@@ -15,8 +15,8 @@ import { cn } from '@/lib/utils'
 
 interface HabitPresetSelectorProps {
   onClose: () => void
-  onSelectPreset: (preset: HabitPreset) => void
   onCreateCustom: () => void
+  onSelectPreset: (preset: HabitPreset) => void
 }
 
 export function HabitPresetSelector({ onClose, onSelectPreset, onCreateCustom }: HabitPresetSelectorProps) {

--- a/src/components/streak/HabitPresetSelector.tsx
+++ b/src/components/streak/HabitPresetSelector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChevronRight, Search, X } from 'lucide-react'
+import { ChevronRight, X } from 'lucide-react'
 import { useState } from 'react'
 import { Button } from '@/components/basics/Button'
 import {
@@ -21,62 +21,53 @@ interface HabitPresetSelectorProps {
 
 export function HabitPresetSelector({ onClose, onSelectPreset, onCreateCustom }: HabitPresetSelectorProps) {
   const [selectedCategory, setSelectedCategory] = useState<PresetCategory>('all')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [showSearch, setShowSearch] = useState(false)
 
   const bgColor = 'var(--orange-9)'
   const bgColorLight = 'var(--orange-8)'
 
-  const filteredPresets = habitPresets.filter((preset) => {
-    const matchesCategory = selectedCategory === 'all' || preset.category === selectedCategory
-    const matchesSearch = preset.name.toLowerCase().includes(searchQuery.toLowerCase())
-    return matchesCategory && (searchQuery === '' || matchesSearch)
-  })
+  const filteredPresets = habitPresets.filter(
+    (preset) => selectedCategory === 'all' || preset.category === selectedCategory
+  )
 
   return (
     <div className="min-h-screen" style={{ backgroundColor: bgColor }}>
-      <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-3">
-        <Button
-          className="h-10 w-10 rounded-full p-0"
-          onClick={onClose}
-          size="icon"
-          style={{ backgroundColor: bgColorLight }}
-          type="button"
-          variant="ghost"
-        >
-          <X className="h-5 w-5 text-white" />
-        </Button>
+      <header className="sticky top-0 z-10 px-4 pt-3 pb-4">
+        <div className="relative flex items-center justify-center">
+          <Button
+            className="absolute left-0 h-10 w-10 rounded-full p-0"
+            onClick={onClose}
+            size="icon"
+            style={{ backgroundColor: bgColorLight }}
+            type="button"
+            variant="ghost"
+          >
+            <X className="h-5 w-5 text-white" />
+          </Button>
 
-        <h1 className="font-semibold text-lg text-white">習慣を追加</h1>
-
-        <Button
-          className="h-10 w-10 rounded-full p-0"
-          onClick={() => setShowSearch(!showSearch)}
-          size="icon"
-          style={{ backgroundColor: bgColorLight }}
-          type="button"
-          variant="ghost"
-        >
-          <Search className="h-5 w-5 text-white" />
-        </Button>
+          <h1 className="font-semibold text-lg text-white">習慣を追加</h1>
+        </div>
       </header>
 
-      {showSearch && (
-        <div className="px-4 pb-3">
-          <input
-            autoFocus
-            className="w-full rounded-xl px-4 py-3 text-white placeholder:text-white/60 focus:outline-none focus:ring-2 focus:ring-white/30"
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="プリセットを検索..."
-            style={{ backgroundColor: bgColorLight }}
-            type="text"
-            value={searchQuery}
-          />
-        </div>
-      )}
+      <div className="px-4 pb-4">
+        <Button
+          className="h-auto w-full justify-start rounded-xl px-4 py-4 text-left text-white/50 hover:bg-white/10"
+          onClick={onCreateCustom}
+          style={{ backgroundColor: bgColorLight }}
+          type="button"
+          variant="ghost"
+        >
+          習慣の名前を入力...
+        </Button>
+      </div>
 
       <div className="px-4 pb-4">
-        <div className="scrollbar-hide flex gap-2 overflow-x-auto">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="h-px flex-1 bg-white/20" />
+          <p className="text-sm text-white/50">またはプリセットから選ぶ</p>
+          <div className="h-px flex-1 bg-white/20" />
+        </div>
+
+        <div className="scrollbar-hide flex gap-2 overflow-x-auto pb-1">
           {presetCategories.map((category) => {
             const IconComponent = category.icon
             const isSelected = selectedCategory === category.id
@@ -100,28 +91,7 @@ export function HabitPresetSelector({ onClose, onSelectPreset, onCreateCustom }:
         </div>
       </div>
 
-      <div className="px-4 pb-4">
-        <p className="text-sm text-white/80 leading-relaxed">
-          プリセットを選択するか、自身でカスタム習慣を作成できます。
-        </p>
-      </div>
-
-      <div className="px-4 pb-2">
-        <p className="mb-2 text-sm text-white/70">自身で作成:</p>
-        <Button
-          className="h-auto w-full justify-start rounded-xl px-4 py-4 text-left text-white/50 hover:bg-white/10"
-          onClick={onCreateCustom}
-          style={{ backgroundColor: bgColorLight }}
-          type="button"
-          variant="ghost"
-        >
-          習慣の名前を入力...
-        </Button>
-      </div>
-
-      <div className="px-4 pt-4">
-        <p className="mb-3 text-sm text-white/70">またはプリセットを選択:</p>
-
+      <div className="px-4 pb-8">
         <div className="space-y-2">
           {filteredPresets.map((preset) => {
             const icon = getIconById(preset.iconId)

--- a/src/components/streak/HabitSimpleView.tsx
+++ b/src/components/streak/HabitSimpleView.tsx
@@ -24,16 +24,16 @@ const HabitActionDrawer = dynamic(
 )
 
 interface HabitSimpleViewProps {
-  habits: HabitWithProgress[]
+  backgroundColor?: string
   completedHabitIds: Set<string>
+  habits: HabitWithProgress[]
   onAddCheckin?: (habitId: string) => Promise<void>
-  onRemoveCheckin?: (habitId: string) => Promise<void>
   onAddHabit: () => void
   onArchiveOptimistic?: (habitId: string) => OptimisticRollback
   onDeleteOptimistic?: (habitId: string) => OptimisticRollback
+  onRemoveCheckin?: (habitId: string) => Promise<void>
   onResetOptimistic?: (habitId: string) => OptimisticRollback
   onSettings?: () => void
-  backgroundColor?: string
 }
 
 function ProgressRing({

--- a/src/components/streak/IconPicker.tsx
+++ b/src/components/streak/IconPicker.tsx
@@ -5,13 +5,13 @@ import { Icon, type IconName } from '@/components/basics/Icon'
 import { cn } from '@/lib/utils'
 
 interface IconPickerProps {
-  selectedIcon: IconName
   onIconSelect: (iconName: IconName) => void
+  selectedIcon: IconName
 }
 
 interface IconCategory {
-  name: string
   icons: IconName[]
+  name: string
 }
 
 const categories: IconCategory[] = [

--- a/src/components/streak/StreakDashboard.tsx
+++ b/src/components/streak/StreakDashboard.tsx
@@ -1,19 +1,17 @@
 'use client'
 
 import { Circle, LayoutGrid } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/basics/Button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DEFAULT_DASHBOARD_VIEW } from '@/constants/dashboard'
 import type { Period } from '@/constants/habit'
 import { useDashboardStats } from '@/hooks/use-dashboard-stats'
-import { usePresetSelection } from '@/hooks/use-preset-selection'
 import { cn } from '@/lib/utils'
 import { setClientCookie } from '@/lib/utils/cookies'
 import { filterHabitsByPeriod } from '@/lib/utils/habits'
-import { HabitForm } from './HabitForm'
 import { HabitListView } from './HabitListView'
-import { HabitPresetSelector } from './HabitPresetSelector'
 import { HabitSimpleView } from './HabitSimpleView'
 import type { DashboardBaseProps } from './types'
 
@@ -22,7 +20,7 @@ interface StreakDashboardProps extends DashboardBaseProps {
 }
 
 type PeriodFilter = 'all' | Period
-type View = 'dashboard' | 'simple' | 'preset-selector' | 'add'
+type View = 'dashboard' | 'simple'
 type MainView = 'dashboard' | 'simple'
 
 const VIEW_COOKIE_KEY = 'ko_dashboard_view'
@@ -37,7 +35,6 @@ const persistMainView = (view: MainView) => {
 
 export function StreakDashboard({
   habits,
-  onAddHabit,
   onAddCheckin,
   onRemoveCheckin,
   onArchiveOptimistic,
@@ -46,14 +43,14 @@ export function StreakDashboard({
   todayLabel,
   initialView = DEFAULT_DASHBOARD_VIEW,
 }: StreakDashboardProps) {
+  const router = useRouter()
   const [currentView, setCurrentView] = useState<View>(initialView)
-  const [returnView, setReturnView] = useState<MainView>(initialView)
   const [periodFilter, setPeriodFilter] = useState<PeriodFilter>('all')
 
-  const { selectedPreset, selectPreset, clearPreset } = usePresetSelection()
   const { completedHabitIds, todayActive, totalDaily, totalStreak } = useDashboardStats(habits)
 
   const filteredHabits = useMemo(() => filterHabitsByPeriod(habits, periodFilter), [habits, periodFilter])
+
   useEffect(() => {
     const root = document.documentElement
     const shouldApply = currentView === 'dashboard' || currentView === 'simple'
@@ -69,55 +66,9 @@ export function StreakDashboard({
     }
   }, [currentView])
 
-  const openPresetSelector = () => {
-    const nextReturnView = currentView === 'simple' ? 'simple' : 'dashboard'
-    setReturnView(nextReturnView)
-    setCurrentView('preset-selector')
-  }
-
   const handleViewChange = (view: View) => {
     setCurrentView(view)
-    if (view === 'dashboard' || view === 'simple') {
-      setReturnView(view)
-      persistMainView(view)
-    }
-  }
-
-  if (currentView === 'preset-selector') {
-    return (
-      <HabitPresetSelector
-        onClose={() => {
-          clearPreset()
-          setCurrentView(returnView)
-        }}
-        onCreateCustom={() => {
-          clearPreset()
-          setCurrentView('add')
-        }}
-        onSelectPreset={(preset) => {
-          selectPreset(preset)
-          setCurrentView('add')
-        }}
-      />
-    )
-  }
-
-  if (currentView === 'add') {
-    return (
-      <HabitForm
-        onBack={() => setCurrentView('preset-selector')}
-        onSubmit={async (input) => {
-          await onAddHabit(input.name, input.icon, {
-            color: input.color,
-            period: input.period,
-            frequency: input.frequency,
-          })
-          clearPreset()
-          setCurrentView(returnView)
-        }}
-        preset={selectedPreset}
-      />
-    )
+    persistMainView(view)
   }
 
   return (
@@ -128,7 +79,7 @@ export function StreakDashboard({
           completedHabitIds={completedHabitIds}
           habits={habits}
           onAddCheckin={onAddCheckin}
-          onAddHabit={openPresetSelector}
+          onAddHabit={() => router.push('/habits/new?step=preset')}
           onArchiveOptimistic={onArchiveOptimistic}
           onDeleteOptimistic={onDeleteOptimistic}
           onRemoveCheckin={onRemoveCheckin}
@@ -142,7 +93,7 @@ export function StreakDashboard({
             filteredHabits={filteredHabits}
             habits={habits}
             onAddCheckin={onAddCheckin}
-            onAddHabit={openPresetSelector}
+            onAddHabit={() => router.push('/habits/new?step=preset')}
             onArchiveOptimistic={onArchiveOptimistic}
             onDeleteOptimistic={onDeleteOptimistic}
             onPeriodChange={setPeriodFilter}

--- a/src/components/streak/TaskCircle.tsx
+++ b/src/components/streak/TaskCircle.tsx
@@ -6,11 +6,11 @@ import { COMPLETION_STATUS_LABEL } from '@/constants/habit'
 import { cn } from '@/lib/utils'
 
 interface TaskCircleProps {
+  color?: string | null
+  completed: boolean
   habitId: string
   habitName: string
   icon?: IconName
-  color?: string | null
-  completed: boolean
   onToggle: (habitId: string) => void
   size?: 'sm' | 'md' | 'lg'
 }

--- a/src/components/streak/TaskGrid.tsx
+++ b/src/components/streak/TaskGrid.tsx
@@ -8,10 +8,10 @@ import type { HabitWithProgress } from '@/types/habit'
 import { TaskCircle } from './TaskCircle'
 
 interface TaskGridProps {
-  habits: HabitWithProgress[]
   completedHabitIds: Set<string>
-  onToggleHabit: (habitId: string) => void
+  habits: HabitWithProgress[]
   onAddClick: () => void
+  onToggleHabit: (habitId: string) => void
 }
 
 export function TaskGrid({ habits, completedHabitIds, onToggleHabit, onAddClick }: TaskGridProps) {

--- a/src/components/streak/types.ts
+++ b/src/components/streak/types.ts
@@ -1,19 +1,12 @@
-import type { IconName } from '@/components/basics/Icon'
 import type { OptimisticRollback } from '@/components/habits/types'
-import type { Period } from '@/constants/habit'
 import type { HabitWithProgress } from '@/types/habit'
 
 export interface DashboardBaseProps {
   habits: HabitWithProgress[]
-  todayLabel: string
-  onAddHabit: (
-    name: string,
-    icon: IconName,
-    options?: { color?: string | null; period?: Period; frequency?: number }
-  ) => Promise<void>
   onAddCheckin?: (habitId: string) => Promise<void>
-  onRemoveCheckin?: (habitId: string) => Promise<void>
   onArchiveOptimistic?: (habitId: string) => OptimisticRollback
   onDeleteOptimistic?: (habitId: string) => OptimisticRollback
+  onRemoveCheckin?: (habitId: string) => Promise<void>
   onResetOptimistic?: (habitId: string) => OptimisticRollback
+  todayLabel: string
 }

--- a/src/constants/habit-data.ts
+++ b/src/constants/habit-data.ts
@@ -180,9 +180,9 @@ export interface PresetCategoryOption {
 export const presetCategories: PresetCategoryOption[] = [
   { id: 'all', label: 'すべて', icon: Sparkles },
   { id: 'health', label: '健康', icon: Heart },
-  { id: 'productivity', label: '生産性', icon: Target },
   { id: 'lifestyle', label: '生活', icon: Coffee },
   { id: 'learning', label: '学習', icon: BookOpen },
+  { id: 'productivity', label: '生産性', icon: Target },
 ]
 
 export interface HabitPreset {

--- a/src/constants/habit-data.ts
+++ b/src/constants/habit-data.ts
@@ -50,16 +50,17 @@ export const habitIcons: HabitIcon[] = [
 ]
 
 export const habitColors = [
-  { id: 'orange', color: 'var(--orange-9)', label: 'オレンジ' },
-  { id: 'red', color: 'var(--red-9)', label: 'レッド' },
-  { id: 'pink', color: 'var(--pink-9)', label: 'ピンク' },
-  { id: 'purple', color: 'var(--purple-9)', label: 'パープル' },
-  { id: 'blue', color: 'var(--blue-9)', label: 'ブルー' },
-  { id: 'cyan', color: 'var(--cyan-9)', label: 'シアン' },
-  { id: 'teal', color: 'var(--teal-9)', label: 'ティール' },
-  { id: 'green', color: 'var(--green-9)', label: 'グリーン' },
-  { id: 'lime', color: 'var(--lime-9)', label: 'ライム' },
-  { id: 'yellow', color: 'var(--yellow-9)', label: 'イエロー' },
+  { id: 'orange', color: 'var(--orange-9)', foreground: 'var(--orange-1)', label: 'オレンジ' },
+  { id: 'red', color: 'var(--red-9)', foreground: 'var(--red-1)', label: 'レッド' },
+  { id: 'pink', color: 'var(--pink-9)', foreground: 'var(--pink-1)', label: 'ピンク' },
+  { id: 'purple', color: 'var(--purple-9)', foreground: 'var(--purple-1)', label: 'パープル' },
+  { id: 'blue', color: 'var(--blue-9)', foreground: 'var(--blue-1)', label: 'ブルー' },
+  { id: 'cyan', color: 'var(--cyan-9)', foreground: 'var(--cyan-1)', label: 'シアン' },
+  { id: 'teal', color: 'var(--teal-9)', foreground: 'var(--teal-1)', label: 'ティール' },
+  { id: 'green', color: 'var(--green-9)', foreground: 'var(--green-1)', label: 'グリーン' },
+  // lime/yellow は step-9 が明るいため step-12（ダーク）を foreground に使う
+  { id: 'lime', color: 'var(--lime-9)', foreground: 'var(--lime-12)', label: 'ライム' },
+  { id: 'yellow', color: 'var(--yellow-9)', foreground: 'var(--yellow-12)', label: 'イエロー' },
 ]
 
 export const oldHabitColors = [

--- a/src/constants/habit-data.ts
+++ b/src/constants/habit-data.ts
@@ -50,17 +50,16 @@ export const habitIcons: HabitIcon[] = [
 ]
 
 export const habitColors = [
-  { id: 'orange', color: 'var(--orange-9)', foreground: 'var(--orange-1)', label: 'オレンジ' },
-  { id: 'red', color: 'var(--red-9)', foreground: 'var(--red-1)', label: 'レッド' },
-  { id: 'pink', color: 'var(--pink-9)', foreground: 'var(--pink-1)', label: 'ピンク' },
-  { id: 'purple', color: 'var(--purple-9)', foreground: 'var(--purple-1)', label: 'パープル' },
-  { id: 'blue', color: 'var(--blue-9)', foreground: 'var(--blue-1)', label: 'ブルー' },
-  { id: 'cyan', color: 'var(--cyan-9)', foreground: 'var(--cyan-1)', label: 'シアン' },
-  { id: 'teal', color: 'var(--teal-9)', foreground: 'var(--teal-1)', label: 'ティール' },
-  { id: 'green', color: 'var(--green-9)', foreground: 'var(--green-1)', label: 'グリーン' },
-  // lime/yellow は step-9 が明るいため step-12（ダーク）を foreground に使う
-  { id: 'lime', color: 'var(--lime-9)', foreground: 'var(--lime-12)', label: 'ライム' },
-  { id: 'yellow', color: 'var(--yellow-9)', foreground: 'var(--yellow-12)', label: 'イエロー' },
+  { id: 'orange', color: 'var(--orange-9)', foreground: 'var(--orange-12)', label: 'オレンジ' },
+  { id: 'red', color: 'var(--red-9)', foreground: 'var(--red-12)', label: 'レッド' },
+  { id: 'pink', color: 'var(--pink-9)', foreground: 'var(--pink-12)', label: 'ピンク' },
+  { id: 'purple', color: 'var(--purple-9)', foreground: 'var(--purple-12)', label: 'パープル' },
+  { id: 'blue', color: 'var(--blue-9)', foreground: 'var(--blue-12)', label: 'ブルー' },
+  { id: 'cyan', color: 'var(--cyan-9)', foreground: 'var(--cyan-12)', label: 'シアン' },
+  { id: 'teal', color: 'var(--teal-9)', foreground: 'var(--teal-12)', label: 'ティール' },
+  { id: 'green', color: 'var(--green-9)', foreground: 'var(--green-12)', label: 'グリーン' },
+  { id: 'lime', color: 'var(--lime-9)', foreground: 'var(--lime-1)', label: 'ライム' },
+  { id: 'yellow', color: 'var(--yellow-9)', foreground: 'var(--yellow-1)', label: 'イエロー' },
 ]
 
 export const oldHabitColors = [

--- a/src/constants/habit-data.ts
+++ b/src/constants/habit-data.ts
@@ -23,8 +23,8 @@ import type { IconName } from '@/components/basics/Icon'
 import type { Period } from '@/constants/habit'
 
 export interface HabitIcon {
-  id: IconName
   icon: LucideIcon
+  id: IconName
   label: string
 }
 
@@ -76,10 +76,10 @@ export const oldHabitColors = [
 ]
 
 export interface TaskPeriodOption {
+  frequencyLabel: string
   id: Period
   label: string
   sublabel: string
-  frequencyLabel: string
 }
 
 export const taskPeriods: TaskPeriodOption[] = [
@@ -89,15 +89,15 @@ export const taskPeriods: TaskPeriodOption[] = [
 ]
 
 export interface Habit {
+  colorId: string
+  createdAt: Date
+  currentProgress: number
+  frequency: number
+  iconId: string
   id: string
   name: string
-  iconId: string
-  colorId: string
   period: Period
-  frequency: number
   streak: number
-  currentProgress: number
-  createdAt: Date
 }
 
 export const sampleHabits: Habit[] = [
@@ -172,9 +172,9 @@ export const sampleHabits: Habit[] = [
 export type PresetCategory = 'all' | 'health' | 'productivity' | 'lifestyle' | 'learning'
 
 export interface PresetCategoryOption {
+  icon: LucideIcon
   id: PresetCategory
   label: string
-  icon: LucideIcon
 }
 
 export const presetCategories: PresetCategoryOption[] = [
@@ -186,13 +186,13 @@ export const presetCategories: PresetCategoryOption[] = [
 ]
 
 export interface HabitPreset {
+  category: PresetCategory
+  colorId: string
+  frequency: number
+  iconId: IconName
   id: string
   name: string
-  iconId: IconName
-  colorId: string
   period: Period
-  frequency: number
-  category: PresetCategory
 }
 
 export const habitPresets: HabitPreset[] = [

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -3,9 +3,9 @@ import { BarChart3, HelpCircle, LayoutDashboard, ListChecks, Settings } from 'lu
 import type { IconName } from '@/components/basics/Icon'
 
 export interface NavItem {
+  icon: LucideIcon
   title: string
   url: string
-  icon: LucideIcon
 }
 
 export const NAV_ITEMS: {
@@ -46,8 +46,8 @@ export const NAV_ITEMS: {
 // Appbar用のシンプルなナビゲーションリンク
 export interface AppbarNavLink {
   href: string
-  label: string
   icon: IconName
+  label: string
 }
 
 export const APPBAR_NAV_LINKS: AppbarNavLink[] = [

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -3,10 +3,10 @@
 import { createContext, useContext, useRef, useState } from 'react'
 
 interface SyncContextValue {
-  pendingCount: number
-  startSync: (id: string) => void
   endSync: (id: string) => void
   isSyncing: boolean
+  pendingCount: number
+  startSync: (id: string) => void
 }
 
 const SyncContext = createContext<SyncContextValue | null>(null)

--- a/src/hooks/use-color-theme.ts
+++ b/src/hooks/use-color-theme.ts
@@ -5,9 +5,9 @@ import { COLOR_THEME_COOKIE_KEY, type ColorThemeName, DEFAULT_COLOR_THEME, isCol
 import { getClientCookie, setClientCookie } from '@/lib/utils/cookies'
 
 interface UseColorTheme {
-  theme: ColorThemeName
-  setTheme: (theme: ColorThemeName) => void
   ready: boolean
+  setTheme: (theme: ColorThemeName) => void
+  theme: ColorThemeName
 }
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365

--- a/src/hooks/use-preset-selection.ts
+++ b/src/hooks/use-preset-selection.ts
@@ -2,9 +2,9 @@ import { useCallback, useState } from 'react'
 import type { HabitPreset } from '@/constants/habit-data'
 
 export interface UsePresetSelectionReturn {
+  clearPreset: () => void
   selectedPreset: HabitPreset | null
   selectPreset: (preset: HabitPreset) => void
-  clearPreset: () => void
 }
 
 export function usePresetSelection(): UsePresetSelectionReturn {

--- a/src/hooks/use-user-settings.ts
+++ b/src/hooks/use-user-settings.ts
@@ -8,10 +8,10 @@ import type { UpdateUserSettingsSchemaType } from '@/schemas/user-settings'
 import type { UserSettings } from '@/types/user-settings'
 
 interface UseUserSettings {
-  settings: UserSettings | null
-  updateSettings: (settings: UpdateUserSettingsSchemaType) => Promise<void>
   ready: boolean
+  settings: UserSettings | null
   syncing: boolean
+  updateSettings: (settings: UpdateUserSettingsSchemaType) => Promise<void>
 }
 
 /**

--- a/src/hooks/use-week-start.ts
+++ b/src/hooks/use-week-start.ts
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react'
 import { DEFAULT_WEEK_START, type WeekStart } from '@/constants/habit'
 
 interface UseWeekStart {
-  weekStart: WeekStart
-  setWeekStart: (weekStart: WeekStart) => void
   ready: boolean
+  setWeekStart: (weekStart: WeekStart) => void
+  weekStart: WeekStart
 }
 
 const STORAGE_KEY = 'week-start'

--- a/src/lib/cache/habit-cache.ts
+++ b/src/lib/cache/habit-cache.ts
@@ -5,10 +5,10 @@ import type { CloudflareEnv, KVNamespace } from '@/types/cloudflare'
 import type { HabitWithProgress } from '@/types/habit'
 
 export interface HabitsCacheData {
-  habits: HabitWithProgress[]
   dateKey: string
-  timestamp: number
+  habits: HabitWithProgress[]
   staleAt?: number
+  timestamp: number
 }
 
 const CACHE_TTL_SECONDS = 180 // 3分（チェックイン更新頻度を考慮）

--- a/src/lib/db-retry.ts
+++ b/src/lib/db-retry.ts
@@ -3,8 +3,8 @@ import { resetDb } from './db'
 
 interface RetryOptions {
   maxRetries?: number
-  retryOn?: (error: unknown) => boolean
   onRetry?: (attempt: number, error: unknown) => Promise<void>
+  retryOn?: (error: unknown) => boolean
   timeoutMs?: number
 }
 

--- a/src/lib/queries/__tests__/checkin.test.ts
+++ b/src/lib/queries/__tests__/checkin.test.ts
@@ -57,10 +57,10 @@ import {
 } from '../checkin'
 
 interface Condition {
-  op: 'and' | 'eq' | 'gte' | 'lte' | 'desc'
-  left?: unknown
-  right?: unknown
   conditions?: Condition[]
+  left?: unknown
+  op: 'and' | 'eq' | 'gte' | 'lte' | 'desc'
+  right?: unknown
 }
 
 describe('getCheckinsByUserAndDate', () => {

--- a/src/lib/queries/checkin.ts
+++ b/src/lib/queries/checkin.ts
@@ -7,15 +7,15 @@ import { profileQuery } from '@/lib/queries/profiler'
 import { normalizeDateKey } from '@/lib/utils/date'
 
 interface CreateCheckinInput {
-  habitId: string
   date: Date | string
+  habitId: string
 }
 
 interface CreateCheckinWithLimitInput {
-  habitId: string
   date: Date | string
-  period: Period
   frequency: number
+  habitId: string
+  period: Period
   weekStartDay?: WeekStartDay
 }
 
@@ -27,9 +27,9 @@ interface CreateCheckinWithLimitInput {
  * @property checkin - 作成されたチェックインレコード（失敗時はnull）
  */
 export interface CreateCheckinWithLimitResult {
+  checkin: typeof checkins.$inferSelect | null
   created: boolean
   currentCount: number
-  checkin: typeof checkins.$inferSelect | null
 }
 
 export async function getCheckinsByUserAndDate(userId: string, date: Date | string) {

--- a/src/schemas/env.ts
+++ b/src/schemas/env.ts
@@ -16,8 +16,8 @@ export type EnvSchema = v.InferOutput<typeof envSchema>
 
 interface EnvInput {
   CLERK_SECRET_KEY?: string
-  CLOUDFLARE_API_TOKEN?: string
   CLOUDFLARE_ACCOUNT_ID?: string
+  CLOUDFLARE_API_TOKEN?: string
   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?: string
   NEXT_PUBLIC_CLERK_SIGN_IN_URL?: string
   NEXT_PUBLIC_CLERK_SIGN_UP_URL?: string

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -25,9 +25,9 @@ export const UserSchema = v.object({
 })
 
 export interface ClerkApiResponseErrorPayload extends Record<string, unknown> {
-  status?: number
   clerkTraceId?: string
   errors?: Array<{ code?: string; message?: string }>
+  status?: number
 }
 
 export type UserSchemaType = v.InferOutput<typeof UserSchema>

--- a/src/transforms/habitFormData.ts
+++ b/src/transforms/habitFormData.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_HABIT_PERIOD,
   type Period,
 } from '@/constants/habit'
+import type { HabitPreset } from '@/constants/habit-data'
 import { type HabitInputSchemaType, safeParseHabitInput } from '@/schemas/habit'
 import type { Habit, HabitWithProgress } from '@/types/habit'
 
@@ -17,23 +18,35 @@ export type HabitFormValues = Omit<HabitInputSchemaType, 'period'> & {
   period: Period
 }
 
-export function getHabitFormDefaults(initialData?: Habit | HabitWithProgress): HabitFormValues {
-  if (initialData) {
+export function getHabitFormDefaults(initialData?: Habit | HabitWithProgress | HabitPreset): HabitFormValues {
+  if (!initialData) {
+    return {
+      name: '',
+      icon: DEFAULT_HABIT_ICON,
+      color: DEFAULT_HABIT_COLOR,
+      period: DEFAULT_HABIT_PERIOD,
+      frequency: DEFAULT_HABIT_FREQUENCY,
+    }
+  }
+
+  // HabitPreset の場合は iconId/colorId を使用
+  if ('category' in initialData) {
     return {
       name: initialData.name,
-      icon: initialData.icon ?? DEFAULT_HABIT_ICON,
-      color: initialData.color ?? DEFAULT_HABIT_COLOR,
+      icon: initialData.iconId,
+      color: initialData.colorId,
       period: initialData.period,
       frequency: initialData.frequency,
     }
   }
 
+  // 既存のHabitの場合（編集時）
   return {
-    name: '',
-    icon: DEFAULT_HABIT_ICON,
-    color: DEFAULT_HABIT_COLOR,
-    period: DEFAULT_HABIT_PERIOD,
-    frequency: DEFAULT_HABIT_FREQUENCY,
+    name: initialData.name,
+    icon: initialData.icon ?? DEFAULT_HABIT_ICON,
+    color: initialData.color ?? DEFAULT_HABIT_COLOR,
+    period: initialData.period,
+    frequency: initialData.frequency,
   }
 }
 

--- a/src/types/cloudflare.ts
+++ b/src/types/cloudflare.ts
@@ -4,10 +4,10 @@
 
 /** KV Namespace インターフェース */
 export interface KVNamespace {
+  delete(key: string): Promise<void>
   get(key: string, type?: 'text'): Promise<string | null>
   get(key: string, type: 'json'): Promise<unknown>
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
-  delete(key: string): Promise<void>
 }
 
 /** Cloudflare Workers 環境変数 */

--- a/src/types/habit.ts
+++ b/src/types/habit.ts
@@ -4,37 +4,37 @@
 import type { Period } from '@/constants/habit'
 
 export interface Habit {
-  id: string
-  name: string
-  icon: string | null
-  color: string | null
-  period: Period
-  frequency: number
-  userId: string
   archived: boolean
   archivedAt: string | null
+  color: string | null
   createdAt: string
+  frequency: number
+  icon: string | null
+  id: string
+  name: string
+  period: Period
   updatedAt: string
+  userId: string
 }
 
 /**
  * 進捗情報を含む習慣型
  */
 export interface HabitWithProgress extends Habit {
+  /** 目標達成率（0-100） */
+  completionRate: number
   /** 現在の期間での達成回数 */
   currentProgress: number
   /** 連続達成日数 */
   streak: number
-  /** 目標達成率（0-100） */
-  completionRate: number
 }
 
 /**
  * チェックイン記録
  */
 export interface HabitCheckin {
-  id: string
-  habitId: string
-  date: string
   createdAt: string
+  date: string
+  habitId: string
+  id: string
 }

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -8,11 +8,11 @@ export type ThemeMode = 'light' | 'dark' | 'system'
  * タイムスタンプは ISO 文字列として扱う
  */
 export interface UserSettings {
+  colorTheme: ColorThemeName
+  createdAt: string
   id: string
+  themeMode: ThemeMode
+  updatedAt: string
   userId: string
   weekStart: WeekStart
-  colorTheme: ColorThemeName
-  themeMode: ThemeMode
-  createdAt: string
-  updatedAt: string
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,10 +1,10 @@
 import type { WeekStart } from '@/constants/habit'
 
 export interface User {
-  id: string
   clerkId: string
-  email: string
-  weekStart: WeekStart
   createdAt: Date
+  email: string
+  id: string
   updatedAt: Date
+  weekStart: WeekStart
 }


### PR DESCRIPTION
## 概要

`/dashboard` と `/habits` の2つの習慣追加フローを統一し、Next.js Intercepting Routes を活用してURLベースのステップ管理を実現しました。

## 変更内容

### Phase 1: プリセット選択統合
- ✅ `getHabitFormDefaults` に `HabitPreset` 型対応を追加
- ✅ `HabitPresetSelectorWrapper` コンポーネント作成（URL遷移制御）
- ✅ `/habits/new/page.tsx` でURLパラメータベースのステップ管理

### Phase 2: モーダル版実装
- ✅ `@modal/(.)habits/new/page.tsx` でプリセット選択とフォーム表示
- ✅ `RouteModal` 内でステップに応じたコンポーネント切り替え

### Phase 3: ダッシュボード変更
- ✅ `StreakDashboard` と `DesktopDashboard` から独自フローを削除
- ✅ `router.push('/habits/new?step=preset')` に統一
- ✅ `DashboardBaseProps` から `onAddHabit` prop削除
- ✅ `DashboardWrapper` の `handleAddHabit` 関数削除
- ✅ `/habits` ページのボタンを `?step=preset` 付きに変更

## メリット

1. **URL不整合の解消**: リロードしても状態が維持される
2. **UXの統一**: どこから開始しても同じウィザード
3. **保守性の向上**: 1つの実装のみ維持

## Breaking Changes

- `DashboardBaseProps.onAddHabit` prop削除
- `/habits/new` への直接リンクはプリセット選択をスキップ
  → `/habits/new?step=preset` でプリセット選択を表示

## テストシナリオ

### TC1: `/dashboard` からの習慣追加
1. `/dashboard` にアクセス
2. 「習慣を追加」ボタンをクリック
3. ✅ URLが `/habits/new?step=preset` に変わる
4. ✅ プリセット選択画面がモーダル表示される
5. プリセットを選択
6. ✅ URLが `/habits/new?step=form&preset={id}` に変わる
7. ✅ フォームにプリセットの初期値が入っている
8. フォーム送信
9. ✅ モーダルが閉じて `/dashboard` に戻る
10. ✅ 新しい習慣が表示される

### TC2: `/habits` からの習慣追加
1. `/habits` にアクセス
2. 「新しい習慣」ボタンをクリック
3. ✅ URLが `/habits/new?step=preset` に変わる
4. ✅ プリセット選択画面がモーダル表示される
5. 「自身で作成」を選択
6. ✅ URLが `/habits/new?step=form` に変わる
7. ✅ フォームが空で表示される
8. フォーム送信
9. ✅ モーダルが閉じて `/habits` に戻る

### TC3: 直接アクセス
1. ブラウザで `/habits/new?step=preset` に直接アクセス
2. ✅ プリセット選択画面がフルページで表示される（モーダルではない）
3. プリセットを選択
4. ✅ `/habits/new?step=form&preset={id}` に遷移
5. ✅ フォームが表示される
6. フォーム送信
7. ✅ `/dashboard` にリダイレクトされる

### TC4: ブラウザバック
1. `/dashboard` → `/habits/new?step=preset` → `/habits/new?step=form`
2. ブラウザバック
3. ✅ プリセット選択に戻る
4. ブラウザバック
5. ✅ `/dashboard` に戻る

## 関連Issue

- Related: #154

## レビューポイント

- [ ] URL遷移の動作確認（モーダル/フルページ）
- [ ] プリセット選択からフォーム送信までのフロー
- [ ] ブラウザバックの挙動
- [ ] 型安全性（`HabitPreset` 対応）