### PR TITLE
fix: preview-cleanup workflow の権限不足と wrangler 未インストール問題を修正

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -9,6 +9,9 @@ jobs:
     name: Cleanup Preview
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -23,6 +26,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Delete Preview Worker
         env:
@@ -57,4 +64,3 @@ jobs:
               issue_number: prNumber,
               body: body
             });
-


### PR DESCRIPTION
## 問題

`Cleanup PR Preview` ワークフローが PR クローズ時に毎回失敗していた。

## 原因

1. **`Command "wrangler" not found`**
   - `pnpm install` を実行せず `pnpm wrangler delete` を呼んでいたため `wrangler` が見つからなかった

2. **`Resource not accessible by integration` (HTTP 403)**
   - `GITHUB_TOKEN` に `pull-requests: write` 権限がなく、PR へのコメント投稿が拒否されていた

## 修正

- `permissions` ブロック（`contents: read` / `pull-requests: write`）を追加
- `Install dependencies` ステップ（`pnpm install --frozen-lockfile`）を追加
- `setup-node@v4` に `cache: "pnpm"` を追加

## 参考

`preview.yml` と同じ構成に揃えた。