### PR TITLE
fix: プレビューワーカーにシークレットを設定

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -71,9 +71,11 @@ jobs:
             PREVIEW_URL="https://${WORKER_NAME}.j138cm.workers.dev"
           fi
 
-          echo "preview_url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "worker_name=${WORKER_NAME}" >> "$GITHUB_OUTPUT"
+          {
+            echo "preview_url=${PREVIEW_URL}"
+            echo "pr_number=${PR_NUMBER}"
+            echo "worker_name=${WORKER_NAME}"
+          } >> "$GITHUB_OUTPUT"
           echo "✅ Preview deployed to: ${PREVIEW_URL}"
 
       - name: Setup Preview Secrets
@@ -84,11 +86,14 @@ jobs:
         run: |
           WORKER_NAME="${{ steps.deploy.outputs.worker_name }}"
 
+          # Install dotenvx (required by generate-secrets-json.sh)
+          pnpm add -g @dotenvx/dotenvx
+
           # Generate secrets JSON using existing script
           ./scripts/generate-secrets-json.sh
 
           # Set secrets on preview worker
-          pnpm wrangler secret bulk .secrets.json --name "${WORKER_NAME}"
+          pnpm wrangler secret bulk .secrets.json --name "${WORKER_NAME}" --env preview
 
           # Clean up
           rm -f .secrets.json

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -73,7 +73,26 @@ jobs:
 
           echo "preview_url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "worker_name=${WORKER_NAME}" >> "$GITHUB_OUTPUT"
           echo "✅ Preview deployed to: ${PREVIEW_URL}"
+
+      - name: Setup Preview Secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
+        run: |
+          WORKER_NAME="${{ steps.deploy.outputs.worker_name }}"
+
+          # Generate secrets JSON using existing script
+          ./scripts/generate-secrets-json.sh
+
+          # Set secrets on preview worker
+          pnpm wrangler secret bulk .secrets.json --name "${WORKER_NAME}"
+
+          # Clean up
+          rm -f .secrets.json
+          echo "✅ Preview secrets configured for ${WORKER_NAME}"
 
       - name: Comment Preview URL
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- プレビューワーカー（`keep-on-pr-*`）が `Internal Server Error` で表示できない問題を修正
- 原因: プレビューワーカーは本番 `keep-on` とは別インスタンスのため、`CLERK_SECRET_KEY` 等のシークレットが存在しなかった
- `preview.yml` にデプロイ後のシークレット設定ステップを追加（既存の `generate-secrets-json.sh` を再利用）

## Test plan
- [ ] PR作成後、プレビューデプロイのCIが成功すること
- [ ] プレビューURL（`https://keep-on-pr-{N}.j138cm.workers.dev`）にアクセスしてページが表示されること