### PR TITLE
feat: カレンダービュー・スキップ保護・リマインダー時刻設定を実装

### DIFF
--- a/drizzle/0003_skip_and_reminder.sql
+++ b/drizzle/0003_skip_and_reminder.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `Habit` ADD COLUMN `reminderTime` text;
+--> statement-breakpoint
+CREATE TABLE `HabitSkip` (
+	`id` text PRIMARY KEY NOT NULL,
+	`habitId` text NOT NULL,
+	`date` text NOT NULL,
+	`createdAt` text NOT NULL,
+	FOREIGN KEY (`habitId`) REFERENCES `Habit`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `HabitSkip_habitId_date_unique` ON `HabitSkip` (`habitId`,`date`);
+--> statement-breakpoint
+CREATE INDEX `HabitSkip_habitId_idx` ON `HabitSkip` (`habitId`);

--- a/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
+++ b/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState, useTransition } from 'react'
 import { addCheckinAction } from '@/app/actions/habits/checkin'
 import { removeCheckinAction } from '@/app/actions/habits/remove-checkin'
+import { addSkipAction, removeSkipAction } from '@/app/actions/habits/skip'
 import { DesktopDashboard } from '@/components/streak/DesktopDashboard'
 import { StreakDashboard } from '@/components/streak/StreakDashboard'
 import {
@@ -394,6 +395,24 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
     return Promise.resolve()
   }
 
+  const handleSkip = async (habitId: string) => {
+    const result = await addSkipAction(habitId)
+    if (!result.ok) {
+      appToast.error('スキップの設定に失敗しました')
+    } else {
+      appToast.success('今日をスキップしました（ストリーク維持）')
+    }
+  }
+
+  const handleUnSkip = async (habitId: string) => {
+    const result = await removeSkipAction(habitId)
+    if (!result.ok) {
+      appToast.error('スキップの解除に失敗しました')
+    } else {
+      appToast.success('スキップを解除しました')
+    }
+  }
+
   const handleViewChange = (view: DashboardView) => {
     setCurrentView(view)
     setClientCookie(DASHBOARD_VIEW_COOKIE_KEY, view, {
@@ -417,6 +436,8 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
           onDeleteOptimistic={deleteOptimistically}
           onRemoveCheckin={handleRemoveCheckin}
           onResetOptimistic={resetOptimistically}
+          onSkip={handleSkip}
+          onUnSkip={handleUnSkip}
           onViewChange={handleViewChange}
           todayLabel={todayLabel}
         />
@@ -432,6 +453,8 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
           onDeleteOptimistic={deleteOptimistically}
           onRemoveCheckin={handleRemoveCheckin}
           onResetOptimistic={resetOptimistically}
+          onSkip={handleSkip}
+          onUnSkip={handleUnSkip}
           onViewChange={handleViewChange}
           todayLabel={todayLabel}
           user={user}

--- a/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
+++ b/src/app/(dashboard)/dashboard/DashboardWrapper.tsx
@@ -397,19 +397,19 @@ export function DashboardWrapper({ habits, todayLabel, user, initialView }: Dash
 
   const handleSkip = async (habitId: string) => {
     const result = await addSkipAction(habitId)
-    if (!result.ok) {
-      appToast.error('スキップの設定に失敗しました')
-    } else {
+    if (result.ok) {
       appToast.success('今日をスキップしました（ストリーク維持）')
+    } else {
+      appToast.error('スキップの設定に失敗しました')
     }
   }
 
   const handleUnSkip = async (habitId: string) => {
     const result = await removeSkipAction(habitId)
-    if (!result.ok) {
-      appToast.error('スキップの解除に失敗しました')
-    } else {
+    if (result.ok) {
       appToast.success('スキップを解除しました')
+    } else {
+      appToast.error('スキップの解除に失敗しました')
     }
   }
 

--- a/src/app/(dashboard)/habits/[id]/page.tsx
+++ b/src/app/(dashboard)/habits/[id]/page.tsx
@@ -1,0 +1,142 @@
+import { notFound, redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ChevronLeft, Flame, Pencil, Target, TrendingUp } from 'lucide-react'
+import { Button } from '@/components/basics/Button'
+import { Icon, normalizeIconName } from '@/components/basics/Icon'
+import { HabitCalendarHeatmap } from '@/components/habits/HabitCalendarHeatmap'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { SIGN_IN_PATH } from '@/constants/auth'
+import { DEFAULT_HABIT_COLOR, PERIOD_DISPLAY_NAME } from '@/constants/habit'
+import { getColorById, getIconById } from '@/constants/habit-data'
+import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
+import { getHabitCalendarData } from '@/lib/queries/habit-calendar'
+import { getHabitById } from '@/lib/queries/habit'
+import { getRequestTimeoutMs } from '@/lib/server/timeout'
+import { getCurrentUserId } from '@/lib/user'
+import type { HabitIdPageProps } from '@/types/route'
+
+export async function generateMetadata({ params }: HabitIdPageProps): Promise<Metadata> {
+  const { id } = await params
+  const habit = await getHabitById(id)
+  return {
+    title: habit ? `${habit.name} - KeepOn` : '習慣詳細 - KeepOn',
+  }
+}
+
+export default async function HabitDetailPage({ params }: HabitIdPageProps) {
+  const timeoutMs = getRequestTimeoutMs()
+  const requestMeta = createRequestMeta('/habits/[id]')
+
+  logInfo('request.habits.detail:start', requestMeta)
+
+  const userId = await logSpanOptional('habits.detail.syncUser', () => getCurrentUserId(), requestMeta, {
+    timeoutMs,
+  })
+
+  if (!userId) {
+    redirect(SIGN_IN_PATH)
+  }
+
+  const { id } = await params
+  const [habit, calendarData] = await Promise.all([
+    logSpan('habits.detail.fetchHabit', () => getHabitById(id), requestMeta, { timeoutMs }),
+    logSpan('habits.detail.fetchCalendar', () => getHabitCalendarData(id), requestMeta, { timeoutMs }),
+  ])
+
+  if (!habit) {
+    notFound()
+  }
+
+  if (habit.userId !== userId) {
+    redirect('/habits')
+  }
+
+  logInfo('request.habits.detail:end', requestMeta)
+
+  const colorData = getColorById(habit.color ?? DEFAULT_HABIT_COLOR)
+  const IconComponent = getIconById(normalizeIconName(habit.icon)).icon
+  const checkinDates = Array.from(calendarData.checkinDates)
+  const skipDates = Array.from(calendarData.skipDates)
+  const totalCheckins = checkinDates.length
+  const periodLabel = PERIOD_DISPLAY_NAME[habit.period]
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button asChild size="sm" variant="ghost">
+          <Link href="/habits">
+            <ChevronLeft className="h-4 w-4" />
+            戻る
+          </Link>
+        </Button>
+        <div className="flex flex-1 items-center gap-3">
+          <div
+            className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full"
+            style={{ backgroundColor: colorData.color }}
+          >
+            <IconComponent className="h-6 w-6 text-white" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate font-bold text-2xl text-foreground">{habit.name}</h1>
+            <p className="text-muted-foreground text-sm">
+              {periodLabel} · {habit.frequency}回
+            </p>
+          </div>
+        </div>
+        <Button asChild size="sm" variant="outline">
+          <Link href={`/habits/${habit.id}/edit`}>
+            <Pencil className="mr-1.5 h-4 w-4" />
+            編集
+          </Link>
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <Card>
+          <CardContent className="flex flex-col items-center gap-1 pt-4 pb-4">
+            <Flame className="h-5 w-5 text-orange-500" />
+            <span className="font-bold text-2xl" style={{ color: colorData.color }}>
+              {totalCheckins}
+            </span>
+            <span className="text-center text-muted-foreground text-xs">総チェックイン</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex flex-col items-center gap-1 pt-4 pb-4">
+            <TrendingUp className="h-5 w-5 text-emerald-500" />
+            <span className="font-bold text-2xl" style={{ color: colorData.color }}>
+              {skipDates.length}
+            </span>
+            <span className="text-center text-muted-foreground text-xs">スキップ回数</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex flex-col items-center gap-1 pt-4 pb-4">
+            <Target className="h-5 w-5 text-sky-500" />
+            <span className="font-bold text-2xl" style={{ color: colorData.color }}>
+              {habit.frequency}
+            </span>
+            <span className="text-center text-muted-foreground text-xs">目標回数</span>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Calendar Heatmap */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">チェックイン履歴（過去6ヶ月）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <HabitCalendarHeatmap
+            accentColor={colorData.color}
+            checkinDates={checkinDates}
+            skipDates={skipDates}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/habits/[id]/page.tsx
+++ b/src/app/(dashboard)/habits/[id]/page.tsx
@@ -1,26 +1,33 @@
-import { notFound, redirect } from 'next/navigation'
+import { ChevronLeft, Flame, Pencil, Target, TrendingUp } from 'lucide-react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { ChevronLeft, Flame, Pencil, Target, TrendingUp } from 'lucide-react'
+import { notFound, redirect } from 'next/navigation'
 import { Button } from '@/components/basics/Button'
-import { Icon, normalizeIconName } from '@/components/basics/Icon'
+import { normalizeIconName } from '@/components/basics/Icon'
 import { HabitCalendarHeatmap } from '@/components/habits/HabitCalendarHeatmap'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SIGN_IN_PATH } from '@/constants/auth'
 import { DEFAULT_HABIT_COLOR, PERIOD_DISPLAY_NAME } from '@/constants/habit'
 import { getColorById, getIconById } from '@/constants/habit-data'
 import { createRequestMeta, logInfo, logSpan, logSpanOptional } from '@/lib/logging'
-import { getHabitCalendarData } from '@/lib/queries/habit-calendar'
 import { getHabitById } from '@/lib/queries/habit'
+import { getHabitCalendarData } from '@/lib/queries/habit-calendar'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { getCurrentUserId } from '@/lib/user'
 import type { HabitIdPageProps } from '@/types/route'
 
 export async function generateMetadata({ params }: HabitIdPageProps): Promise<Metadata> {
   const { id } = await params
+  const userId = await getCurrentUserId()
+  if (!userId) {
+    return { title: '習慣詳細 - KeepOn' }
+  }
   const habit = await getHabitById(id)
+  if (!habit || habit.userId !== userId) {
+    return { title: '習慣詳細 - KeepOn' }
+  }
   return {
-    title: habit ? `${habit.name} - KeepOn` : '習慣詳細 - KeepOn',
+    title: `${habit.name} - KeepOn`,
   }
 }
 
@@ -130,11 +137,7 @@ export default async function HabitDetailPage({ params }: HabitIdPageProps) {
           <CardTitle className="text-base">チェックイン履歴（過去6ヶ月）</CardTitle>
         </CardHeader>
         <CardContent>
-          <HabitCalendarHeatmap
-            accentColor={colorData.color}
-            checkinDates={checkinDates}
-            skipDates={skipDates}
-          />
+          <HabitCalendarHeatmap accentColor={colorData.color} checkinDates={checkinDates} skipDates={skipDates} />
         </CardContent>
       </Card>
     </div>

--- a/src/app/actions/habits/skip.ts
+++ b/src/app/actions/habits/skip.ts
@@ -6,11 +6,7 @@ import { createRequestMeta } from '@/lib/logging'
 import { createSkip, deleteSkip } from '@/lib/queries/skip'
 import { getRequestTimeoutMs } from '@/lib/server/timeout'
 import { validateHabitActionInput } from '@/validators/habit-action'
-import {
-  createHabitCheckinSpans,
-  requireCheckinUserId,
-  requireHabitForUserWithRetry,
-} from './checkin-shared'
+import { createHabitCheckinSpans, requireCheckinUserId, requireHabitForUserWithRetry } from './checkin-shared'
 import { type HabitActionResult, revalidateHabitPaths, serializeActionError } from './utils'
 
 export async function addSkipAction(habitId: string, dateKey?: string): HabitActionResult<{ skipped: boolean }> {

--- a/src/app/actions/habits/skip.ts
+++ b/src/app/actions/habits/skip.ts
@@ -1,0 +1,110 @@
+'use server'
+
+import { Result } from '@praha/byethrow'
+import { toActionResult } from '@/lib/actions/result'
+import { createRequestMeta } from '@/lib/logging'
+import { createSkip, deleteSkip } from '@/lib/queries/skip'
+import { getRequestTimeoutMs } from '@/lib/server/timeout'
+import { validateHabitActionInput } from '@/validators/habit-action'
+import {
+  createHabitCheckinSpans,
+  requireCheckinUserId,
+  requireHabitForUserWithRetry,
+} from './checkin-shared'
+import { type HabitActionResult, revalidateHabitPaths, serializeActionError } from './utils'
+
+export async function addSkipAction(habitId: string, dateKey?: string): HabitActionResult<{ skipped: boolean }> {
+  const requestMeta = createRequestMeta('action.habits.skip')
+  const timeoutMs = getRequestTimeoutMs()
+  const spans = createHabitCheckinSpans(timeoutMs)
+
+  const result = await Result.pipe(
+    validateHabitActionInput({ habitId, dateKey }),
+    Result.andThen(async (input) => {
+      const baseMeta = { ...requestMeta, habitId: input.habitId }
+      return await Result.try({
+        try: async () => {
+          return await spans.runWithRequestTimeout(
+            'action.habits.skip',
+            async () => {
+              const userId = await requireCheckinUserId('action.habits.skip', baseMeta, spans.timeoutMs)
+              const metaWithUser = { ...baseMeta, userId }
+
+              await requireHabitForUserWithRetry({
+                habitId: input.habitId,
+                userId,
+                meta: metaWithUser,
+                runWithRetry: spans.runWithRetry,
+                actionName: 'action.habits.skip',
+              })
+
+              const targetDate = input.dateKey ?? new Date()
+              const skip = await spans.runWithDbTimeout(
+                'action.habits.skip.createSkip',
+                () => createSkip(input.habitId, targetDate),
+                metaWithUser
+              )
+
+              await revalidateHabitPaths(userId, { sync: true })
+
+              return { skipped: skip !== null }
+            },
+            baseMeta
+          )
+        },
+        catch: (error) => error,
+      })
+    }),
+    Result.mapError((error) => serializeActionError(error, 'スキップの設定に失敗しました'))
+  )
+
+  return toActionResult(result)
+}
+
+export async function removeSkipAction(habitId: string, dateKey?: string): HabitActionResult {
+  const requestMeta = createRequestMeta('action.habits.remove-skip')
+  const timeoutMs = getRequestTimeoutMs()
+  const spans = createHabitCheckinSpans(timeoutMs)
+
+  const result = await Result.pipe(
+    validateHabitActionInput({ habitId, dateKey }),
+    Result.andThen(async (input) => {
+      const baseMeta = { ...requestMeta, habitId: input.habitId }
+      return await Result.try({
+        try: async () => {
+          return await spans.runWithRequestTimeout(
+            'action.habits.remove-skip',
+            async () => {
+              const userId = await requireCheckinUserId('action.habits.remove-skip', baseMeta, spans.timeoutMs)
+              const metaWithUser = { ...baseMeta, userId }
+
+              await requireHabitForUserWithRetry({
+                habitId: input.habitId,
+                userId,
+                meta: metaWithUser,
+                runWithRetry: spans.runWithRetry,
+                actionName: 'action.habits.remove-skip',
+              })
+
+              const targetDate = input.dateKey ?? new Date()
+              await spans.runWithDbTimeout(
+                'action.habits.remove-skip.deleteSkip',
+                () => deleteSkip(input.habitId, targetDate),
+                metaWithUser
+              )
+
+              await revalidateHabitPaths(userId, { sync: true })
+
+              return undefined
+            },
+            baseMeta
+          )
+        },
+        catch: (error) => error,
+      })
+    }),
+    Result.mapError((error) => serializeActionError(error, 'スキップの解除に失敗しました'))
+  )
+
+  return toActionResult(result)
+}

--- a/src/components/dashboard/HabitActionDrawer.tsx
+++ b/src/components/dashboard/HabitActionDrawer.tsx
@@ -129,12 +129,7 @@ export function HabitActionDrawer({
             {!isArchived && (
               <>
                 {(onSkip || onUnSkip) && (
-                  <Button
-                    className="col-span-2"
-                    disabled={isSkipping}
-                    onClick={handleSkipToggle}
-                    variant="outline"
-                  >
+                  <Button className="col-span-2" disabled={isSkipping} onClick={handleSkipToggle} variant="outline">
                     {activeHabit?.skippedToday ? '今日のスキップを解除' : '今日をスキップ（ストリーク維持）'}
                   </Button>
                 )}

--- a/src/components/dashboard/HabitActionDrawer.tsx
+++ b/src/components/dashboard/HabitActionDrawer.tsx
@@ -16,6 +16,8 @@ interface HabitActionDrawerProps {
   onDeleteOptimistic?: OptimisticHandler
   onOpenChange: (open: boolean) => void
   onResetOptimistic?: OptimisticHandler
+  onSkip?: (habitId: string) => Promise<void>
+  onUnSkip?: (habitId: string) => Promise<void>
   open: boolean
 }
 
@@ -26,10 +28,13 @@ export function HabitActionDrawer({
   onArchiveOptimistic,
   onDeleteOptimistic,
   onResetOptimistic,
+  onSkip,
+  onUnSkip,
 }: HabitActionDrawerProps) {
   const router = useRouter()
   const [dialogType, setDialogType] = useState<'reset' | 'archive' | 'delete' | null>(null)
   const [activeHabit, setActiveHabit] = useState<HabitWithProgress | null>(null)
+  const [isSkipping, setIsSkipping] = useState(false)
   const prevOpenRef = useRef(open)
 
   useEffect(() => {
@@ -72,6 +77,32 @@ export function HabitActionDrawer({
     }, 350)
   }
 
+  const handleSkipToggle = async () => {
+    if (!activeHabit || isSkipping) {
+      return
+    }
+    setIsSkipping(true)
+    try {
+      if (activeHabit.skippedToday) {
+        await onUnSkip?.(activeHabit.id)
+      } else {
+        await onSkip?.(activeHabit.id)
+      }
+      onOpenChange(false)
+    } finally {
+      setIsSkipping(false)
+    }
+  }
+
+  const handleViewDetail = () => {
+    onOpenChange(false)
+    setTimeout(() => {
+      if (activeHabit) {
+        router.push(`/habits/${activeHabit.id}`)
+      }
+    }, 350)
+  }
+
   if (!(activeHabit || dialogType)) {
     return null
   }
@@ -91,8 +122,22 @@ export function HabitActionDrawer({
               編集
             </Button>
 
+            <Button className="col-span-2" onClick={handleViewDetail} variant="outline">
+              カレンダー履歴を見る
+            </Button>
+
             {!isArchived && (
               <>
+                {(onSkip || onUnSkip) && (
+                  <Button
+                    className="col-span-2"
+                    disabled={isSkipping}
+                    onClick={handleSkipToggle}
+                    variant="outline"
+                  >
+                    {activeHabit?.skippedToday ? '今日のスキップを解除' : '今日をスキップ（ストリーク維持）'}
+                  </Button>
+                )}
                 <Button className="col-span-2" onClick={() => openDialog('reset')} variant="outline">
                   進捗をリセット
                 </Button>

--- a/src/components/habits/HabitCalendarHeatmap.tsx
+++ b/src/components/habits/HabitCalendarHeatmap.tsx
@@ -23,6 +23,47 @@ interface DayCell {
 
 const WEEKDAY_LABELS = ['月', '火', '水', '木', '金', '土', '日']
 
+function getCellStyle(cell: DayCell, accentColor: string) {
+  if (cell.isCheckin) {
+    return { backgroundColor: accentColor }
+  }
+  if (cell.isSkip) {
+    return { border: `2px dashed ${accentColor}`, backgroundColor: `${accentColor}20` }
+  }
+  return undefined
+}
+
+function getCellTitle(cell: DayCell): string {
+  if (cell.isCheckin) {
+    return `${cell.dateKey} ✓`
+  }
+  if (cell.isSkip) {
+    return `${cell.dateKey} スキップ`
+  }
+  return cell.dateKey
+}
+
+interface CalendarCellProps {
+  accentColor: string
+  cell: DayCell
+}
+
+function CalendarCell({ cell, accentColor }: CalendarCellProps) {
+  return (
+    <div
+      className={cn(
+        'aspect-square rounded-sm',
+        !cell.isCurrentMonth && 'opacity-30',
+        cell.isFuture && 'opacity-10',
+        !(cell.isCheckin || cell.isSkip) && 'bg-muted'
+      )}
+      key={cell.dateKey}
+      style={getCellStyle(cell, accentColor)}
+      title={getCellTitle(cell)}
+    />
+  )
+}
+
 function buildMonthGrid(month: Date, checkinSet: Set<string>, skipSet: Set<string>, today: Date): DayCell[][] {
   const start = startOfMonth(month)
   const end = endOfMonth(month)
@@ -124,7 +165,7 @@ export function HabitCalendarHeatmap({
         const monthLabel = format(month, 'yyyy年M月', { locale: ja })
 
         return (
-          <div key={monthLabel} className="space-y-2">
+          <div className="space-y-2" key={monthLabel}>
             <div className="font-medium text-foreground text-sm">{monthLabel}</div>
             {/* Weekday headers */}
             <div className="grid grid-cols-7 gap-1">
@@ -140,32 +181,7 @@ export function HabitCalendarHeatmap({
                 // biome-ignore lint/suspicious/noArrayIndexKey: stable week index
                 <div className="grid grid-cols-7 gap-1" key={wi}>
                   {week.map((cell) => (
-                    <div
-                      className={cn(
-                        'aspect-square rounded-sm',
-                        !cell.isCurrentMonth && 'opacity-30',
-                        cell.isFuture && 'opacity-10',
-                        !cell.isCheckin && !cell.isSkip && 'bg-muted'
-                      )}
-                      key={cell.dateKey}
-                      style={
-                        cell.isCheckin
-                          ? { backgroundColor: accentColor }
-                          : cell.isSkip
-                            ? {
-                                border: `2px dashed ${accentColor}`,
-                                backgroundColor: `${accentColor}20`,
-                              }
-                            : undefined
-                      }
-                      title={
-                        cell.isCheckin
-                          ? `${cell.dateKey} ✓`
-                          : cell.isSkip
-                            ? `${cell.dateKey} スキップ`
-                            : cell.dateKey
-                      }
-                    />
+                    <CalendarCell accentColor={accentColor} cell={cell} key={cell.dateKey} />
                   ))}
                 </div>
               ))}

--- a/src/components/habits/HabitCalendarHeatmap.tsx
+++ b/src/components/habits/HabitCalendarHeatmap.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { addDays, eachDayOfInterval, endOfMonth, format, getDay, startOfMonth, subMonths } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import { useMemo } from 'react'
+import { cn } from '@/lib/utils'
+
+interface HabitCalendarHeatmapProps {
+  accentColor: string
+  checkinDates: string[]
+  months?: number
+  skipDates?: string[]
+}
+
+interface DayCell {
+  date: Date
+  dateKey: string
+  isCheckin: boolean
+  isCurrentMonth: boolean
+  isFuture: boolean
+  isSkip: boolean
+}
+
+const WEEKDAY_LABELS = ['月', '火', '水', '木', '金', '土', '日']
+
+function buildMonthGrid(month: Date, checkinSet: Set<string>, skipSet: Set<string>, today: Date): DayCell[][] {
+  const start = startOfMonth(month)
+  const end = endOfMonth(month)
+  const days = eachDayOfInterval({ start, end })
+
+  // 月曜始まり: 0=Mon, 1=Tue, ..., 6=Sun
+  const startWeekday = (getDay(start) + 6) % 7 // 0=Mon
+  const prefixCount = startWeekday
+
+  const cells: DayCell[] = []
+
+  // prefix empty cells
+  for (let i = 0; i < prefixCount; i++) {
+    const d = addDays(start, -(prefixCount - i))
+    const dateKey = format(d, 'yyyy-MM-dd')
+    cells.push({
+      date: d,
+      dateKey,
+      isCheckin: checkinSet.has(dateKey),
+      isSkip: skipSet.has(dateKey),
+      isCurrentMonth: false,
+      isFuture: d > today,
+    })
+  }
+
+  for (const day of days) {
+    const dateKey = format(day, 'yyyy-MM-dd')
+    cells.push({
+      date: day,
+      dateKey,
+      isCheckin: checkinSet.has(dateKey),
+      isSkip: skipSet.has(dateKey),
+      isCurrentMonth: true,
+      isFuture: day > today,
+    })
+  }
+
+  // pad to multiple of 7
+  while (cells.length % 7 !== 0) {
+    const d = addDays(end, cells.length - prefixCount - days.length + 1)
+    const dateKey = format(d, 'yyyy-MM-dd')
+    cells.push({
+      date: d,
+      dateKey,
+      isCheckin: checkinSet.has(dateKey),
+      isSkip: skipSet.has(dateKey),
+      isCurrentMonth: false,
+      isFuture: d > today,
+    })
+  }
+
+  // split into weeks
+  const weeks: DayCell[][] = []
+  for (let i = 0; i < cells.length; i += 7) {
+    weeks.push(cells.slice(i, i + 7))
+  }
+  return weeks
+}
+
+export function HabitCalendarHeatmap({
+  checkinDates,
+  skipDates = [],
+  accentColor,
+  months = 6,
+}: HabitCalendarHeatmapProps) {
+  const today = useMemo(() => new Date(), [])
+
+  const checkinSet = useMemo(() => new Set(checkinDates), [checkinDates])
+  const skipSet = useMemo(() => new Set(skipDates), [skipDates])
+
+  const monthList = useMemo(() => {
+    const result: Date[] = []
+    for (let i = months - 1; i >= 0; i--) {
+      result.push(subMonths(today, i))
+    }
+    return result
+  }, [today, months])
+
+  return (
+    <div className="space-y-6">
+      {/* Legend */}
+      <div className="flex items-center gap-4 text-muted-foreground text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="h-3 w-3 rounded-sm" style={{ backgroundColor: accentColor }} />
+          <span>チェックイン</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="h-3 w-3 rounded-sm border-2 border-dashed" style={{ borderColor: accentColor }} />
+          <span>スキップ</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="h-3 w-3 rounded-sm bg-muted" />
+          <span>未達成</span>
+        </div>
+      </div>
+
+      {monthList.map((month) => {
+        const weeks = buildMonthGrid(month, checkinSet, skipSet, today)
+        const monthLabel = format(month, 'yyyy年M月', { locale: ja })
+
+        return (
+          <div key={monthLabel} className="space-y-2">
+            <div className="font-medium text-foreground text-sm">{monthLabel}</div>
+            {/* Weekday headers */}
+            <div className="grid grid-cols-7 gap-1">
+              {WEEKDAY_LABELS.map((label) => (
+                <div className="text-center text-muted-foreground text-xs" key={label}>
+                  {label}
+                </div>
+              ))}
+            </div>
+            {/* Calendar grid */}
+            <div className="space-y-1">
+              {weeks.map((week, wi) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: stable week index
+                <div className="grid grid-cols-7 gap-1" key={wi}>
+                  {week.map((cell) => (
+                    <div
+                      className={cn(
+                        'aspect-square rounded-sm',
+                        !cell.isCurrentMonth && 'opacity-30',
+                        cell.isFuture && 'opacity-10',
+                        !cell.isCheckin && !cell.isSkip && 'bg-muted'
+                      )}
+                      key={cell.dateKey}
+                      style={
+                        cell.isCheckin
+                          ? { backgroundColor: accentColor }
+                          : cell.isSkip
+                            ? {
+                                border: `2px dashed ${accentColor}`,
+                                backgroundColor: `${accentColor}20`,
+                              }
+                            : undefined
+                      }
+                      title={
+                        cell.isCheckin
+                          ? `${cell.dateKey} ✓`
+                          : cell.isSkip
+                            ? `${cell.dateKey} スキップ`
+                            : cell.dateKey
+                      }
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/habits/HabitFormServer.tsx
+++ b/src/components/habits/HabitFormServer.tsx
@@ -352,30 +352,48 @@ export function HabitFormServer({
           )}
         />
 
-        {/* Reminder Section (Future Feature) */}
-        <div className="space-y-3">
-          <div className="font-medium text-muted-foreground text-sm uppercase tracking-wide">リマインダー</div>
-          <Button
-            className="h-auto w-full cursor-not-allowed justify-between rounded-xl border border-border bg-card p-4 opacity-50 hover:bg-card/80"
-            disabled
-            type="button"
-            variant="ghost"
-          >
-            <div className="flex items-center gap-3">
-              <div
-                className="flex h-10 w-10 items-center justify-center rounded-full"
-                style={{ backgroundColor: `${selectedColorValue}20` }}
-              >
-                <Clock className="h-5 w-5" style={{ color: selectedColorValue }} />
-              </div>
-              <div className="text-left">
-                <p className="font-medium text-foreground">通知を設定</p>
-                <p className="text-muted-foreground text-sm">{currentPeriod.sublabel}同じ時間にリマインド</p>
+        {/* Reminder Section */}
+        <Controller
+          control={form.control}
+          name="reminderTime"
+          render={({ field }) => (
+            <div className="space-y-3">
+              <div className="font-medium text-muted-foreground text-sm uppercase tracking-wide">リマインダー</div>
+              <div className="rounded-xl border border-border bg-card p-4">
+                <div className="flex items-center gap-3">
+                  <div
+                    className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full"
+                    style={{ backgroundColor: `${selectedColorValue}20` }}
+                  >
+                    <Clock className="h-5 w-5" style={{ color: selectedColorValue }} />
+                  </div>
+                  <div className="flex flex-1 items-center justify-between gap-3">
+                    <div className="text-left">
+                      <p className="font-medium text-foreground">通知時刻</p>
+                      <p className="text-muted-foreground text-sm">未設定の場合はリマインドなし</p>
+                    </div>
+                    <input
+                      className="rounded-lg border border-border bg-background px-3 py-2 text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring/50"
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                      style={{ '--tw-ring-color': selectedColorValue } as React.CSSProperties}
+                      type="time"
+                      value={field.value ?? ''}
+                    />
+                  </div>
+                </div>
+                {field.value && (
+                  <button
+                    className="mt-3 w-full text-center text-muted-foreground text-sm hover:text-foreground"
+                    onClick={() => field.onChange(null)}
+                    type="button"
+                  >
+                    リマインダーを解除
+                  </button>
+                )}
               </div>
             </div>
-            <ChevronLeft className="h-5 w-5 rotate-180 text-muted-foreground" />
-          </Button>
-        </div>
+          )}
+        />
 
         {/* Preview Card */}
         <HabitPreviewCard

--- a/src/components/habits/HabitTable.tsx
+++ b/src/components/habits/HabitTable.tsx
@@ -68,6 +68,7 @@ export async function HabitTable({ userId, clerkId, requestMeta }: HabitTablePro
     currentProgress: 0,
     streak: 0,
     completionRate: 0,
+    skippedToday: false,
   }))
 
   // 両方をマージ

--- a/src/components/streak/DesktopDashboard.tsx
+++ b/src/components/streak/DesktopDashboard.tsx
@@ -29,6 +29,8 @@ export function DesktopDashboard({
   onArchiveOptimistic,
   onDeleteOptimistic,
   onResetOptimistic,
+  onSkip,
+  onUnSkip,
   todayLabel,
   currentView,
   onViewChange,
@@ -68,6 +70,8 @@ export function DesktopDashboard({
             onPeriodChange={setPeriodFilter}
             onRemoveCheckin={onRemoveCheckin}
             onResetOptimistic={onResetOptimistic}
+            onSkip={onSkip}
+            onUnSkip={onUnSkip}
             periodFilter={periodFilter}
             todayActive={todayActive}
             todayLabel={todayLabel}

--- a/src/components/streak/DesktopDashboard.tsx
+++ b/src/components/streak/DesktopDashboard.tsx
@@ -56,6 +56,8 @@ export function DesktopDashboard({
           onRemoveCheckin={onRemoveCheckin}
           onResetOptimistic={onResetOptimistic}
           onSettings={() => onViewChange('dashboard')}
+          onSkip={onSkip}
+          onUnSkip={onUnSkip}
         />
       ) : (
         <div className="space-y-6 p-6">

--- a/src/components/streak/HabitListView.tsx
+++ b/src/components/streak/HabitListView.tsx
@@ -32,6 +32,8 @@ interface HabitListViewProps {
   onPeriodChange: (filter: 'all' | Period) => void
   onRemoveCheckin?: (habitId: string) => Promise<void>
   onResetOptimistic?: (habitId: string) => OptimisticRollback
+  onSkip?: (habitId: string) => Promise<void>
+  onUnSkip?: (habitId: string) => Promise<void>
   periodFilter: 'all' | Period
   todayActive: number
   todayLabel: string
@@ -51,6 +53,8 @@ export function HabitListView({
   onArchiveOptimistic,
   onDeleteOptimistic,
   onResetOptimistic,
+  onSkip,
+  onUnSkip,
   todayActive,
   todayLabel,
   totalDaily,
@@ -176,6 +180,8 @@ export function HabitListView({
           }
         }}
         onResetOptimistic={drawerHabitId && onResetOptimistic ? () => onResetOptimistic(drawerHabitId) : undefined}
+        onSkip={drawerHabitId && onSkip ? () => onSkip(drawerHabitId) : undefined}
+        onUnSkip={drawerHabitId && onUnSkip ? () => onUnSkip(drawerHabitId) : undefined}
         open={drawerState.open}
       />
       {/* リセット確認ダイアログ（達成時のみ表示） */}

--- a/src/components/streak/HabitSimpleView.tsx
+++ b/src/components/streak/HabitSimpleView.tsx
@@ -36,6 +36,8 @@ interface HabitSimpleViewProps {
   onRemoveCheckin?: (habitId: string) => Promise<void>
   onResetOptimistic?: (habitId: string) => OptimisticRollback
   onSettings?: () => void
+  onSkip?: (habitId: string) => Promise<void>
+  onUnSkip?: (habitId: string) => Promise<void>
 }
 
 export function HabitSimpleView({
@@ -48,6 +50,8 @@ export function HabitSimpleView({
   onDeleteOptimistic,
   onResetOptimistic,
   onSettings,
+  onSkip,
+  onUnSkip,
   backgroundColor,
 }: HabitSimpleViewProps) {
   const router = useRouter()
@@ -272,6 +276,8 @@ export function HabitSimpleView({
           }
         }}
         onResetOptimistic={drawerHabitId && onResetOptimistic ? () => onResetOptimistic(drawerHabitId) : undefined}
+        onSkip={drawerHabitId && onSkip ? () => onSkip(drawerHabitId) : undefined}
+        onUnSkip={drawerHabitId && onUnSkip ? () => onUnSkip(drawerHabitId) : undefined}
         open={drawerState.open}
       />
 

--- a/src/components/streak/StreakDashboard.tsx
+++ b/src/components/streak/StreakDashboard.tsx
@@ -28,6 +28,8 @@ export function StreakDashboard({
   onArchiveOptimistic,
   onDeleteOptimistic,
   onResetOptimistic,
+  onSkip,
+  onUnSkip,
   todayLabel,
   currentView,
   onViewChange,
@@ -82,6 +84,8 @@ export function StreakDashboard({
             onPeriodChange={setPeriodFilter}
             onRemoveCheckin={onRemoveCheckin}
             onResetOptimistic={onResetOptimistic}
+            onSkip={onSkip}
+            onUnSkip={onUnSkip}
             periodFilter={periodFilter}
             todayActive={todayActive}
             todayLabel={todayLabel}

--- a/src/components/streak/types.ts
+++ b/src/components/streak/types.ts
@@ -8,5 +8,7 @@ export interface DashboardBaseProps {
   onDeleteOptimistic?: (habitId: string) => OptimisticRollback
   onRemoveCheckin?: (habitId: string) => Promise<void>
   onResetOptimistic?: (habitId: string) => OptimisticRollback
+  onSkip?: (habitId: string) => Promise<void>
+  onUnSkip?: (habitId: string) => Promise<void>
   todayLabel: string
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2'
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 import {
   DEFAULT_HABIT_COLOR,
   DEFAULT_HABIT_FREQUENCY,
@@ -91,6 +91,8 @@ export const habits = sqliteTable(
       .notNull(),
     /** 期間内の目標回数 */
     frequency: integer('frequency').default(DEFAULT_HABIT_FREQUENCY).notNull(),
+    /** リマインダー時刻 (HH:MM形式, nullable) */
+    reminderTime: text('reminderTime'),
     /** アーカイブ済みフラグ */
     archived: integer('archived', { mode: 'boolean' }).default(false).notNull(),
     /** アーカイブ日時 (ISO8601形式) */
@@ -133,5 +135,33 @@ export const checkins = sqliteTable(
   },
   (table) => ({
     habitDateIndex: index('Checkin_habitId_date_idx').on(table.habitId, table.date),
+  })
+)
+
+/**
+ * スキップテーブル
+ * 意図的にスキップした日を記録（ストリークを維持したまま休む）
+ */
+export const habitSkips = sqliteTable(
+  'HabitSkip',
+  {
+    /** スキップID (CUID2形式) */
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    /** 習慣ID (外部キー: habits.id) */
+    habitId: text('habitId')
+      .notNull()
+      .references(() => habits.id, { onDelete: 'cascade' }),
+    /** スキップ日付 (YYYY-MM-DD形式) */
+    date: text('date').notNull(),
+    /** レコード作成日時 (ISO8601形式) */
+    createdAt: text('createdAt')
+      .$defaultFn(() => new Date().toISOString())
+      .notNull(),
+  },
+  (table) => ({
+    habitDateUniqueIndex: uniqueIndex('HabitSkip_habitId_date_unique').on(table.habitId, table.date),
+    habitIdIndex: index('HabitSkip_habitId_idx').on(table.habitId),
   })
 )

--- a/src/lib/queries/__tests__/habit.test.ts
+++ b/src/lib/queries/__tests__/habit.test.ts
@@ -206,6 +206,11 @@ describe('getHabitsWithProgress', () => {
         { id: 'checkin-1', habitId: 'habit-daily', date: new Date(2024, 0, 17), createdAt: baseDate },
         { id: 'checkin-5', habitId: 'habit-weekly', date: new Date(2024, 0, 17), createdAt: baseDate },
       ])
+    // スキップクエリ（3回目の where() 呼び出し）のモック
+    vi.mocked(db.where)
+      .mockReturnValueOnce(db as any)
+      .mockReturnValueOnce(db as any)
+      .mockResolvedValueOnce([])
 
     const result = await getHabitsWithProgress('user-123', 'clerk-123', baseDate)
 
@@ -246,6 +251,11 @@ describe('getHabitsWithProgress', () => {
       .mockResolvedValueOnce([
         { id: 'checkin-mon', habitId: 'habit-weekly-sun', date: new Date(2024, 0, 8), createdAt: sundayBaseDate },
       ])
+    // スキップクエリ（3回目の where() 呼び出し）のモック
+    vi.mocked(db.where)
+      .mockReturnValueOnce(db as any)
+      .mockReturnValueOnce(db as any)
+      .mockResolvedValueOnce([])
 
     const result = await getHabitsWithProgress('user-123', 'clerk-123', sundayBaseDate)
 
@@ -275,6 +285,11 @@ describe('getHabitsWithProgress', () => {
       .mockResolvedValueOnce([
         { id: 'checkin-invalid', habitId: 'habit-invalid', date: new Date(2024, 0, 20), createdAt: invalidDate },
       ])
+    // スキップクエリ（3回目の where() 呼び出し）のモック
+    vi.mocked(db.where)
+      .mockReturnValueOnce(db as any)
+      .mockReturnValueOnce(db as any)
+      .mockResolvedValueOnce([])
 
     const result = await getHabitsWithProgress('user-123', 'clerk-123', invalidDate)
 

--- a/src/lib/queries/habit-calendar.ts
+++ b/src/lib/queries/habit-calendar.ts
@@ -1,0 +1,47 @@
+import { and, eq, gte } from 'drizzle-orm'
+import { checkins, habitSkips } from '@/db/schema'
+import { getDb } from '@/lib/db'
+import { formatDateKey } from '@/lib/utils/date'
+import { profileQuery } from './profiler'
+
+export interface HabitCalendarData {
+  checkinDates: Set<string>
+  skipDates: Set<string>
+}
+
+/**
+ * 習慣の過去6ヶ月分のチェックイン + スキップ日を取得
+ *
+ * @param habitId - 習慣ID
+ * @returns チェックイン日セット・スキップ日セット
+ */
+export async function getHabitCalendarData(habitId: string): Promise<HabitCalendarData> {
+  return await profileQuery(
+    'query.getHabitCalendarData',
+    async () => {
+      const db = getDb()
+
+      // 6ヶ月前の日付を計算
+      const sixMonthsAgo = new Date()
+      sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+      const startDateKey = formatDateKey(sixMonthsAgo)
+
+      const [checkinRows, skipRows] = await Promise.all([
+        db
+          .select({ date: checkins.date })
+          .from(checkins)
+          .where(and(eq(checkins.habitId, habitId), gte(checkins.date, startDateKey))),
+        db
+          .select({ date: habitSkips.date })
+          .from(habitSkips)
+          .where(and(eq(habitSkips.habitId, habitId), gte(habitSkips.date, startDateKey))),
+      ])
+
+      return {
+        checkinDates: new Set(checkinRows.map((r) => r.date)),
+        skipDates: new Set(skipRows.map((r) => r.date)),
+      }
+    },
+    { habitId }
+  )
+}

--- a/src/lib/queries/habit.ts
+++ b/src/lib/queries/habit.ts
@@ -637,8 +637,11 @@ function calculateStreakFromCheckins(
     const count = checkinsByPeriod.get(periodKey) ?? 0
     const skipped = skippedPeriods.has(periodKey)
 
-    if (count >= normalizedFrequency || skipped) {
+    if (count >= normalizedFrequency) {
       streak++
+      currentDate = getPreviousPeriod(currentDate, normalizedPeriod)
+    } else if (skipped) {
+      // スキップ期間はストリークを維持するが、カウントは増やさない
       currentDate = getPreviousPeriod(currentDate, normalizedPeriod)
     } else {
       return streak

--- a/src/lib/queries/habit.ts
+++ b/src/lib/queries/habit.ts
@@ -8,7 +8,7 @@ import {
   type WeekStartDay,
   weekStartToDay,
 } from '@/constants/habit'
-import { checkins, habits } from '@/db/schema'
+import { checkins, habitSkips, habits } from '@/db/schema'
 import { getHabitsCacheSnapshot, setHabitsCache } from '@/lib/cache/habit-cache'
 import { getDb } from '@/lib/db'
 import { formatError, isDatabaseError, logInfo, logWarn, nowMs } from '@/lib/logging'
@@ -121,6 +121,7 @@ export async function createHabit(input: HabitInput) {
           color: input.color,
           period: input.period,
           frequency: input.frequency,
+          reminderTime: input.reminderTime,
         })
         .returning()
       return habit
@@ -462,9 +463,19 @@ export async function getHabitsWithProgress(
             .where(inArray(checkins.habitId, habitIds))
             .orderBy(checkins.habitId, desc(checkins.date), desc(checkins.createdAt))
 
-    // ユーザーの週開始日設定とチェックイン取得を並列化
+    // スキップ取得を並列化
+    const allSkipsPromise: Promise<(typeof habitSkips.$inferSelect)[]> =
+      habitIds.length === 0
+        ? Promise.resolve([])
+        : db.select().from(habitSkips).where(inArray(habitSkips.habitId, habitIds))
+
+    // ユーザーの週開始日設定・チェックイン・スキップ取得を並列化
     const weekStartPromise = weekStart ? Promise.resolve(weekStart) : getUserWeekStart(clerkId)
-    const [weekStartStr, allCheckins] = await Promise.all([weekStartPromise, allCheckinsPromise])
+    const [weekStartStr, allCheckins, allSkips] = await Promise.all([
+      weekStartPromise,
+      allCheckinsPromise,
+      allSkipsPromise,
+    ])
     const weekStartDay = weekStartToDay(weekStartStr)
 
     // 習慣ごとにチェックインをグループ化
@@ -473,6 +484,14 @@ export async function getHabitsWithProgress(
       const existing = checkinsByHabit.get(checkin.habitId) ?? []
       existing.push(checkin)
       checkinsByHabit.set(checkin.habitId, existing)
+    }
+
+    // 習慣ごとにスキップをグループ化
+    const skipsByHabit = new Map<string, typeof allSkips>()
+    for (const skip of allSkips) {
+      const existing = skipsByHabit.get(skip.habitId) ?? []
+      existing.push(skip)
+      skipsByHabit.set(skip.habitId, existing)
     }
 
     // 各習慣の進捗とストリークを計算
@@ -486,6 +505,7 @@ export async function getHabitsWithProgress(
         context: 'getHabitsWithProgress',
       })
       const habitCheckins = checkinsByHabit.get(habit.id) ?? []
+      const habitSkipList = skipsByHabit.get(habit.id) ?? []
 
       // 現在の期間の進捗を計算
       const { start, end } = getPeriodDateRange(baseDate, normalizedPeriod, weekStartDay)
@@ -494,7 +514,10 @@ export async function getHabitsWithProgress(
         return checkinDate >= start && checkinDate <= end
       }).length
 
-      // ストリークを計算
+      // 今日スキップ済みかどうかを確認
+      const skippedToday = habitSkipList.some((s) => s.date === dateKey)
+
+      // ストリークを計算（スキップを考慮）
       const streak = calculateStreakFromCheckins(
         {
           id: habit.id,
@@ -503,7 +526,8 @@ export async function getHabitsWithProgress(
         },
         habitCheckins,
         weekStartDay,
-        baseDate
+        baseDate,
+        habitSkipList
       )
 
       const completionRate = Math.min(
@@ -516,6 +540,7 @@ export async function getHabitsWithProgress(
         period: normalizedPeriod,
         frequency: normalizedFrequency,
         currentProgress,
+        skippedToday,
         streak,
         completionRate,
       }
@@ -562,9 +587,10 @@ function calculateStreakFromCheckins(
   habit: { id: string; frequency: number; period: Period },
   checkins: Array<{ date: Date | string }>,
   weekStartDay: WeekStartDay = 1,
-  baseDate: Date | string = new Date()
+  baseDate: Date | string = new Date(),
+  skips: Array<{ date: Date | string }> = []
 ): number {
-  if (checkins.length === 0) {
+  if (checkins.length === 0 && skips.length === 0) {
     return 0
   }
   const normalizedPeriod = normalizePeriod(habit.period, {
@@ -587,12 +613,21 @@ function calculateStreakFromCheckins(
     checkinsByPeriod.set(periodKey, (checkinsByPeriod.get(periodKey) ?? 0) + 1)
   }
 
-  // 現在の期間の達成状況を確認
+  // スキップ済み期間をSetで管理
+  const skippedPeriods = new Set<string>()
+  for (const skip of skips) {
+    const skipDate = normalizeCheckinDate(skip.date)
+    const periodKey = getPeriodKey(skipDate, normalizedPeriod, weekStartDay)
+    skippedPeriods.add(periodKey)
+  }
+
+  // 現在の期間の達成状況を確認（チェックインまたはスキップ）
   const currentPeriodKey = getPeriodKey(currentDate, normalizedPeriod, weekStartDay)
   const currentCount = checkinsByPeriod.get(currentPeriodKey) ?? 0
+  const currentSkipped = skippedPeriods.has(currentPeriodKey)
 
-  // 現在の期間が未達成の場合、前の期間から開始
-  if (currentCount < normalizedFrequency) {
+  // 現在の期間が未達成かつスキップなしの場合、前の期間から開始
+  if (currentCount < normalizedFrequency && !currentSkipped) {
     currentDate = getPreviousPeriod(currentDate, normalizedPeriod)
   }
 
@@ -600,8 +635,9 @@ function calculateStreakFromCheckins(
   for (let iteration = 0; iteration < MAX_STREAK_ITERATIONS; iteration += 1) {
     const periodKey = getPeriodKey(currentDate, normalizedPeriod, weekStartDay)
     const count = checkinsByPeriod.get(periodKey) ?? 0
+    const skipped = skippedPeriods.has(periodKey)
 
-    if (count >= normalizedFrequency) {
+    if (count >= normalizedFrequency || skipped) {
       streak++
       currentDate = getPreviousPeriod(currentDate, normalizedPeriod)
     } else {

--- a/src/lib/queries/skip.ts
+++ b/src/lib/queries/skip.ts
@@ -1,0 +1,118 @@
+import { and, eq, gte, inArray, lte } from 'drizzle-orm'
+import { habitSkips } from '@/db/schema'
+import { getDb } from '@/lib/db'
+import { normalizeDateKey } from '@/lib/utils/date'
+import { profileQuery } from './profiler'
+
+/**
+ * 習慣のスキップを作成
+ *
+ * @param habitId - 習慣ID
+ * @param date - スキップ日付
+ * @returns 作成されたスキップ、またはnull（既にスキップ済みの場合）
+ */
+export async function createSkip(habitId: string, date: Date | string) {
+  return await profileQuery(
+    'query.createSkip',
+    async () => {
+      const db = getDb()
+      const dateKey = normalizeDateKey(date)
+
+      try {
+        const [skip] = await db
+          .insert(habitSkips)
+          .values({ habitId, date: dateKey })
+          .returning()
+        return skip ?? null
+      } catch (error) {
+        const errorMessage = String(error)
+        if (errorMessage.includes('UNIQUE')) {
+          return null
+        }
+        throw error
+      }
+    },
+    { habitId }
+  )
+}
+
+/**
+ * 習慣のスキップを削除
+ *
+ * @param habitId - 習慣ID
+ * @param date - スキップ日付
+ * @returns 削除成功フラグ
+ */
+export async function deleteSkip(habitId: string, date: Date | string) {
+  return await profileQuery(
+    'query.deleteSkip',
+    async () => {
+      const db = getDb()
+      const dateKey = normalizeDateKey(date)
+
+      const result = await db
+        .delete(habitSkips)
+        .where(and(eq(habitSkips.habitId, habitId), eq(habitSkips.date, dateKey)))
+        .returning()
+
+      return result.length > 0
+    },
+    { habitId }
+  )
+}
+
+/**
+ * 複数の習慣IDのスキップを取得
+ *
+ * @param habitIds - 習慣IDの配列
+ * @returns スキップの配列
+ */
+export async function getSkipsByHabitIds(habitIds: string[]) {
+  if (habitIds.length === 0) {
+    return []
+  }
+
+  return await profileQuery(
+    'query.getSkipsByHabitIds',
+    async () => {
+      const db = getDb()
+      return await db
+        .select()
+        .from(habitSkips)
+        .where(inArray(habitSkips.habitId, habitIds))
+    },
+    { habitCount: habitIds.length }
+  )
+}
+
+/**
+ * 特定の日付範囲のスキップを取得
+ *
+ * @param habitId - 習慣ID
+ * @param startDateKey - 開始日付 (YYYY-MM-DD)
+ * @param endDateKey - 終了日付 (YYYY-MM-DD)
+ * @returns スキップの配列
+ */
+export async function getSkipsByHabitAndDateRange(
+  habitId: string,
+  startDateKey: string,
+  endDateKey: string
+) {
+  return await profileQuery(
+    'query.getSkipsByHabitAndDateRange',
+    async () => {
+      const db = getDb()
+      return await db
+        .select()
+        .from(habitSkips)
+        .where(
+          and(
+            eq(habitSkips.habitId, habitId),
+            gte(habitSkips.date, startDateKey),
+            lte(habitSkips.date, endDateKey)
+          )
+        )
+    },
+    { habitId, startDateKey, endDateKey }
+  )
+}

--- a/src/lib/queries/skip.ts
+++ b/src/lib/queries/skip.ts
@@ -19,10 +19,7 @@ export async function createSkip(habitId: string, date: Date | string) {
       const dateKey = normalizeDateKey(date)
 
       try {
-        const [skip] = await db
-          .insert(habitSkips)
-          .values({ habitId, date: dateKey })
-          .returning()
+        const [skip] = await db.insert(habitSkips).values({ habitId, date: dateKey }).returning()
         return skip ?? null
       } catch (error) {
         const errorMessage = String(error)
@@ -76,10 +73,7 @@ export async function getSkipsByHabitIds(habitIds: string[]) {
     'query.getSkipsByHabitIds',
     async () => {
       const db = getDb()
-      return await db
-        .select()
-        .from(habitSkips)
-        .where(inArray(habitSkips.habitId, habitIds))
+      return await db.select().from(habitSkips).where(inArray(habitSkips.habitId, habitIds))
     },
     { habitCount: habitIds.length }
   )
@@ -93,11 +87,7 @@ export async function getSkipsByHabitIds(habitIds: string[]) {
  * @param endDateKey - 終了日付 (YYYY-MM-DD)
  * @returns スキップの配列
  */
-export async function getSkipsByHabitAndDateRange(
-  habitId: string,
-  startDateKey: string,
-  endDateKey: string
-) {
+export async function getSkipsByHabitAndDateRange(habitId: string, startDateKey: string, endDateKey: string) {
   return await profileQuery(
     'query.getSkipsByHabitAndDateRange',
     async () => {
@@ -106,11 +96,7 @@ export async function getSkipsByHabitAndDateRange(
         .select()
         .from(habitSkips)
         .where(
-          and(
-            eq(habitSkips.habitId, habitId),
-            gte(habitSkips.date, startDateKey),
-            lte(habitSkips.date, endDateKey)
-          )
+          and(eq(habitSkips.habitId, habitId), gte(habitSkips.date, startDateKey), lte(habitSkips.date, endDateKey))
         )
     },
     { habitId, startDateKey, endDateKey }

--- a/src/schemas/habit.ts
+++ b/src/schemas/habit.ts
@@ -6,6 +6,21 @@ import { DEFAULT_HABIT_PERIOD, PERIODS } from '@/constants/habit'
  */
 export const PeriodSchema = v.picklist(PERIODS)
 
+/** HH:MM形式の時刻バリデーション */
+const ReminderTimeSchema = v.pipe(
+  v.nullable(v.optional(v.string())),
+  v.transform((val): string | null => {
+    if (!val?.trim()) {
+      return null
+    }
+    // HH:MM 形式チェック
+    if (/^\d{2}:\d{2}$/.test(val.trim())) {
+      return val.trim()
+    }
+    return null
+  })
+)
+
 /**
  * 習慣入力のバリデーションスキーマ
  */
@@ -31,6 +46,7 @@ export const HabitInputSchema = v.pipe(
       v.minValue(1, 'Frequency must be at least 1'),
       v.maxValue(100, 'Frequency is too large (max 100)')
     ),
+    reminderTime: ReminderTimeSchema,
   })
 )
 

--- a/src/schemas/habit.ts
+++ b/src/schemas/habit.ts
@@ -6,19 +6,22 @@ import { DEFAULT_HABIT_PERIOD, PERIODS } from '@/constants/habit'
  */
 export const PeriodSchema = v.picklist(PERIODS)
 
-/** HH:MM形式の時刻バリデーション */
-const ReminderTimeSchema = v.pipe(
-  v.nullable(v.optional(v.string())),
-  v.transform((val): string | null => {
-    if (!val?.trim()) {
+/** HH:MM形式の時刻バリデーション（オプショナル、デフォルト null） */
+const ReminderTimeSchema = v.optional(
+  v.pipe(
+    v.nullable(v.string()),
+    v.transform((val): string | null => {
+      if (!val?.trim()) {
+        return null
+      }
+      // HH:MM 形式チェック
+      if (/^\d{2}:\d{2}$/.test(val.trim())) {
+        return val.trim()
+      }
       return null
-    }
-    // HH:MM 形式チェック
-    if (/^\d{2}:\d{2}$/.test(val.trim())) {
-      return val.trim()
-    }
-    return null
-  })
+    })
+  ),
+  null
 )
 
 /**

--- a/src/transforms/habitFormData.ts
+++ b/src/transforms/habitFormData.ts
@@ -26,6 +26,7 @@ export function getHabitFormDefaults(initialData?: Habit | HabitWithProgress | H
       color: DEFAULT_HABIT_COLOR,
       period: DEFAULT_HABIT_PERIOD,
       frequency: DEFAULT_HABIT_FREQUENCY,
+      reminderTime: null,
     }
   }
 
@@ -37,6 +38,7 @@ export function getHabitFormDefaults(initialData?: Habit | HabitWithProgress | H
       color: initialData.colorId,
       period: initialData.period,
       frequency: initialData.frequency,
+      reminderTime: null,
     }
   }
 
@@ -47,6 +49,7 @@ export function getHabitFormDefaults(initialData?: Habit | HabitWithProgress | H
     color: initialData.color ?? DEFAULT_HABIT_COLOR,
     period: initialData.period,
     frequency: initialData.frequency,
+    reminderTime: initialData.reminderTime ?? null,
   }
 }
 
@@ -61,6 +64,9 @@ export function buildHabitFormData(input: HabitInputSchemaType): FormData {
   }
   formData.append('period', input.period)
   formData.append('frequency', String(input.frequency))
+  if (input.reminderTime) {
+    formData.append('reminderTime', input.reminderTime)
+  }
   return formData
 }
 
@@ -105,6 +111,7 @@ export function transformHabitInput(formData: FormData) {
     color: getString('color'),
     period: periodRaw,
     frequency,
+    reminderTime: getString('reminderTime'),
   }
 }
 
@@ -159,6 +166,11 @@ export function transformHabitUpdate(formData: FormData) {
 
   if (frequency !== undefined) {
     input.frequency = frequency
+  }
+
+  const reminderTime = getString('reminderTime')
+  if (reminderTime !== undefined) {
+    input.reminderTime = reminderTime || null
   }
 
   return input

--- a/src/types/habit.ts
+++ b/src/types/habit.ts
@@ -13,6 +13,7 @@ export interface Habit {
   id: string
   name: string
   period: Period
+  reminderTime: string | null
   updatedAt: string
   userId: string
 }
@@ -25,6 +26,8 @@ export interface HabitWithProgress extends Habit {
   completionRate: number
   /** 現在の期間での達成回数 */
   currentProgress: number
+  /** 今日スキップ済みかどうか */
+  skippedToday: boolean
   /** 連続達成日数 */
   streak: number
 }

--- a/src/validators/__tests__/habit.test.ts
+++ b/src/validators/__tests__/habit.test.ts
@@ -24,6 +24,7 @@ describe('validateHabitInput', () => {
         color: null,
         period: 'daily',
         frequency: 1,
+        reminderTime: null,
       })
     }
   })

--- a/src/validators/habit.ts
+++ b/src/validators/habit.ts
@@ -44,6 +44,7 @@ export function validateHabitInput(userId: string, formData: FormData): Result.R
     color: parseResult.output.color,
     period: parseResult.output.period,
     frequency: parseResult.output.frequency,
+    reminderTime: parseResult.output.reminderTime,
   })
 }
 


### PR DESCRIPTION
## 概要

高優先度の3機能を実装しました。

### 1. カレンダービュー（習慣ヒートマップ）
- `/habits/[id]` に習慣詳細ページを新規作成
- 過去6ヶ月のGitHub contributions風ヒートマップ表示
- チェックイン日（アクセントカラー）/ スキップ日（点線）/ 未達成日を色分け
- 統計カード（総チェックイン・スキップ回数・目標回数）

### 2. スキップ機能（ストリーク保護）
- HabitSkip テーブル追加（DBマイグレーション: `drizzle/0003_skip_and_reminder.sql`）
- 「今日をスキップ（ストリーク維持）」ボタンをダッシュボードのアクションDrawerに追加
- スキップした日はストリーク計算から除外（継続扱い）
- `addSkipAction` / `removeSkipAction` Server Actions

### 3. リマインダー時刻設定
- Habit テーブルに `reminderTime` カラム追加（HH:MM形式）
- 習慣作成・編集フォームのリマインダーセクションを有効化（`<input type="time">`）
- スキーマ→バリデーター→トランスフォーム→クエリ全体に伝播

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [x] API / Server Actions
- [x] データベース (Drizzle ORM)
- [ ] 認証 (Clerk)
- [ ] PWA
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`mise run check`)
- [ ] Cloudflare ビルド確認 (`pnpm build:cf`)
- [x] Edge Runtime 制約を考慮（Node.js API の使用を避ける）
- [x] Drizzle 変更時: スキーマ検証とマイグレーション確認 (`pnpm db:generate`)
- [ ] 環境変数の変更時: `.env` を暗号化 (`pnpm env:encrypt`)

## 変更ファイル

- `src/db/schema.ts` — HabitSkip テーブル・reminderTime カラム追加
- `drizzle/0003_skip_and_reminder.sql` — DBマイグレーション
- `src/lib/queries/habit-calendar.ts` — カレンダーデータ取得クエリ（新規）
- `src/lib/queries/skip.ts` — スキップCRUDクエリ（新規）
- `src/app/actions/habits/skip.ts` — スキップServer Actions（新規）
- `src/components/habits/HabitCalendarHeatmap.tsx` — ヒートマップコンポーネント（新規）
- `src/app/(dashboard)/habits/[id]/page.tsx` — 習慣詳細ページ（新規）
- `src/components/habits/HabitFormServer.tsx` — リマインダー入力UI有効化
- `src/components/dashboard/HabitActionDrawer.tsx` — スキップUI追加
- `src/components/streak/types.ts`
- `src/components/streak/StreakDashboard.tsx`
- `src/components/dashboard/DesktopDashboard.tsx`
- `src/components/dashboard/HabitListView.tsx` — `onSkip` / `onUnSkip` プロップスのバケツリレー
- `src/app/(dashboard)/dashboard/DashboardWrapper.tsx` — `handleSkip` / `handleUnSkip` ハンドラー追加

---
